### PR TITLE
Added option to not use jQuery

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -25,12 +25,24 @@ add_tooltip <- function(dn, id, str) {
     .Call('rvg_add_tooltip', PACKAGE = 'rvg', dn, id, str)
 }
 
+add_tooltip_raw <- function(dn, id, str) {
+    .Call('rvg_add_tooltip_raw', PACKAGE = 'rvg', dn, id, str)
+}
+
 add_click_event <- function(dn, id, str) {
     .Call('rvg_add_click_event', PACKAGE = 'rvg', dn, id, str)
 }
 
+add_click_event_raw <- function(dn, id, str) {
+    .Call('rvg_add_click_event_raw', PACKAGE = 'rvg', dn, id, str)
+}
+
 add_data_id <- function(dn, id, data_id) {
     .Call('rvg_add_data_id', PACKAGE = 'rvg', dn, id, data_id)
+}
+
+add_data_id_raw <- function(dn, id, data_id) {
+    .Call('rvg_add_data_id_raw', PACKAGE = 'rvg', dn, id, data_id)
 }
 
 PPTX_ <- function(file, bg_, width, height, offx, offy, pointsize, fontname_serif, fontname_sans, fontname_mono, fontname_symbol, editable, id, raster_prefix, next_rels_id, standalone) {

--- a/R/interactivePointsGrob.R
+++ b/R/interactivePointsGrob.R
@@ -6,12 +6,14 @@
 #' @param tooltip tooltip associated with points
 #' @param onclick javascript action to execute when point is clicked
 #' @param data_id identifiers to associate with points
+#' @param use_jquery logical indicating whether to rely on jQuery or not (default: "\code{TRUE}")
 #' @export
 interactivePointsGrob <- function( x = unit(0.5, "npc"),
 		y = unit(0.5, "npc"),
 		tooltip = NULL,
 		onclick = NULL,
 		data_id = NULL,
+		use_jquery = TRUE,
 		pch=1, size=unit(1, "char"),
 		default.units="native",
 		name=NULL, gp=gpar(), vp=NULL) {
@@ -19,7 +21,7 @@ interactivePointsGrob <- function( x = unit(0.5, "npc"),
 		x <- unit(x, default.units)
 	if (!is.unit(y))
 		y <- unit(y, default.units)
-	grob(tooltip = tooltip, onclick = onclick, data_id = data_id,
+	grob(tooltip = tooltip, onclick = onclick, data_id = data_id, use_jquery,
 			x = x, y = y, pch = pch, size=size,
 			name=name, gp=gp, vp=vp, cl="interactivePointsGrob")
 }
@@ -28,19 +30,21 @@ interactivePointsGrob <- function( x = unit(0.5, "npc"),
 #' @title interactivePointsGrob drawing
 #' @description draw an interactivePointsGrob
 #' @inheritParams grid::drawDetails
-drawDetails.interactivePointsGrob <- function(x,recording) {
+drawDetails.interactivePointsGrob <- function(x, recording) {
 	rvg_tracer_on()
 	grid.points(x = x$x, y = x$y, pch = x$pch, size = x$size, default.units = "native", gp = x$gp )
 	ids = rvg_tracer_off()
+
+  use_jquery <- x$use_jquery %||% TRUE
+
 	if( length( ids ) > 0 ) {
 		if( !is.null( x$tooltip ))
-			send_tooltip(ids, x$tooltip)
+			send_tooltip(ids, x$tooltip, use_jquery)
 		if( !is.null( x$onclick ))
-			send_click(ids, x$onclick)
+			send_click(ids, x$onclic, use_jquery)
 		if( !is.null( x$data_id ))
-			set_data_id(ids, x$data_id)
+			set_data_id(ids, x$data_id, use_jquery)
 	}
-
 
 	invisible()
 }

--- a/R/interactivePointsGrob.R
+++ b/R/interactivePointsGrob.R
@@ -21,7 +21,7 @@ interactivePointsGrob <- function( x = unit(0.5, "npc"),
 		x <- unit(x, default.units)
 	if (!is.unit(y))
 		y <- unit(y, default.units)
-	grob(tooltip = tooltip, onclick = onclick, data_id = data_id, use_jquery,
+	grob(tooltip = tooltip, onclick = onclick, data_id = data_id, use_jquery = use_jquery,
 			x = x, y = y, pch = pch, size=size,
 			name=name, gp=gp, vp=vp, cl="interactivePointsGrob")
 }

--- a/R/interactivePolygonGrob.R
+++ b/R/interactivePolygonGrob.R
@@ -6,6 +6,7 @@
 #' @param tooltip tooltip associated with polygons
 #' @param onclick javascript action to execute when polygon is clicked
 #' @param data_id identifiers to associate with polygons
+#' @param use_jquery logical indicating whether to rely on jQuery or not (default: "\code{TRUE}")
 #' @export
 interactivePolygonGrob <- function(x=unit(c(0, 1), "npc"),
 		y=unit(c(0, 1), "npc"),
@@ -13,6 +14,7 @@ interactivePolygonGrob <- function(x=unit(c(0, 1), "npc"),
 		tooltip = NULL,
 		onclick = NULL,
 		data_id = NULL,
+		use_jquery = TRUE,
 		default.units="npc",
 		name=NULL, gp=gpar(), vp=NULL) {
 	# Allow user to specify unitless vector;  add default units
@@ -20,7 +22,7 @@ interactivePolygonGrob <- function(x=unit(c(0, 1), "npc"),
 		x <- unit(x, default.units)
 	if (!is.unit(y))
 		y <- unit(y, default.units)
-	grob(tooltip = tooltip, onclick = onclick, data_id = data_id,
+	grob(tooltip = tooltip, onclick = onclick, data_id = data_id, use_jquery = use_jquery,
 			x=x, y=y, id=id, id.lengths=id.lengths,
 			name=name, gp=gp, vp=vp, cl="interactivePolygonGrob")
 }
@@ -31,7 +33,7 @@ interactivePolygonGrob <- function(x=unit(c(0, 1), "npc"),
 #' @inheritParams grid::drawDetails
 drawDetails.interactivePolygonGrob <- function(x,recording) {
 	rvg_tracer_on()
-	argnames = setdiff( names(x), c("tooltip", "onclick", "data_id") )
+	argnames = setdiff( names(x), c("tooltip", "onclick", "data_id", "use_jquery") )
 	do.call( grid.polygon, x[argnames] )
 	ids = rvg_tracer_off()
 	if( length( ids ) > 0 ) {
@@ -41,12 +43,14 @@ drawDetails.interactivePolygonGrob <- function(x,recording) {
 
 	  posid = which(!duplicated(x$id))
 
+	  use_jquery <- x$use_jquery %||% TRUE
+
 		if( !is.null( x$tooltip ))
-			send_tooltip(ids, x$tooltip[posid])
+			send_tooltip(ids, x$tooltip[posid], use_jquery)
 		if( !is.null( x$onclick ))
-			send_click(ids, x$onclick[posid])
+			send_click(ids, x$onclick[posid], use_jquery)
 		if( !is.null( x$data_id ))
-			set_data_id(ids, x$data_id[posid])
+			set_data_id(ids, x$data_id[posid], use_jquery)
 
 	}
 

--- a/R/interactivePolylineGrob.R
+++ b/R/interactivePolylineGrob.R
@@ -6,6 +6,7 @@
 #' @param tooltip tooltip associated with polylines
 #' @param onclick javascript action to execute when polyline is clicked
 #' @param data_id identifiers to associate with polylines
+#' @param use_jquery logical indicating whether to rely on jQuery or not (default: "\code{TRUE}")
 #' @export
 interactivePolylineGrob <- function(x=unit(c(0, 1), "npc"),
 		y=unit(c(0, 1), "npc"),
@@ -13,6 +14,7 @@ interactivePolylineGrob <- function(x=unit(c(0, 1), "npc"),
 		tooltip = NULL,
 		onclick = NULL,
 		data_id = NULL,
+		use_jquery = TRUE,
 		default.units="npc",
 		arrow=NULL,
 		name=NULL, gp=gpar(), vp=NULL) {
@@ -21,7 +23,7 @@ interactivePolylineGrob <- function(x=unit(c(0, 1), "npc"),
 		x <- unit(x, default.units)
 	if (!is.unit(y))
 		y <- unit(y, default.units)
-	grob(tooltip = tooltip, onclick = onclick, data_id = data_id,
+	grob(tooltip = tooltip, onclick = onclick, data_id = data_id, use_jquery = use_jquery,
 			x=x, y=y, id=id, id.lengths=id.lengths,
 			arrow=arrow, name=name, gp=gp, vp=vp, cl="interactivePolylineGrob")
 }
@@ -32,10 +34,13 @@ interactivePolylineGrob <- function(x=unit(c(0, 1), "npc"),
 #' @inheritParams grid::drawDetails
 drawDetails.interactivePolylineGrob <- function(x,recording) {
 	rvg_tracer_on()
-	argnames = setdiff( names(x), c("tooltip", "onclick", "data_id") )
+	argnames = setdiff( names(x), c("tooltip", "onclick", "data_id", "use_jquery") )
 	do.call( grid.polyline, x[argnames] )
 
 	ids = rvg_tracer_off()
+
+	use_jquery <- x$use_jquery %||% TRUE
+
 	if( length( ids ) > 0 ) {
 
 	  if( is.null(x$id) && is.null(x$id.lengths) )
@@ -52,7 +57,7 @@ drawDetails.interactivePolylineGrob <- function(x,recording) {
 		      length(ids) != length(tooltip) ){
 		    tooltip <- rep( tooltip, each = length(ids) %/% length(tooltip) )
 		  }
-		  send_tooltip(ids, tooltip)
+		  send_tooltip(ids, tooltip, use_jquery)
 		}
 
 		if( !is.null( x$onclick )){
@@ -64,7 +69,7 @@ drawDetails.interactivePolylineGrob <- function(x,recording) {
 		      length(ids) != length(onclick) ){
 		    onclick <- rep( onclick, each = length(ids) %/% length(onclick) )
 		  }
-			send_click(ids, onclick)
+			send_click(ids, onclick, use_jquery)
 		}
 		if( !is.null( x$data_id )){
 		  data_id <- x$data_id[.w]
@@ -75,7 +80,7 @@ drawDetails.interactivePolylineGrob <- function(x,recording) {
 		      length(ids) != length(data_id) ){
 		    data_id <- rep( data_id, each = length(ids) %/% length(data_id) )
 		  }
-			set_data_id(ids, data_id)
+			set_data_id(ids, data_id, use_jquery)
     }
 	}
 

--- a/R/interactiveRectGrob.R
+++ b/R/interactiveRectGrob.R
@@ -6,12 +6,14 @@
 #' @param tooltip tooltip associated with rectangles
 #' @param onclick javascript action to execute when rectangle is clicked
 #' @param data_id identifiers to associate with rectangles
+#' @param use_jquery logical indicating whether to rely on jQuery or not (default: "\code{TRUE}")
 #' @export
 interactiveRectGrob <- function(x=unit(0.5, "npc"), y=unit(0.5, "npc"),
 		width=unit(1, "npc"), height=unit(1, "npc"),
 		tooltip = NULL,
 		onclick = NULL,
 		data_id = NULL,
+		use_jquery = TRUE,
 		just="centre", hjust=NULL, vjust=NULL,
 		default.units="npc",
 		name=NULL, gp=gpar(), vp=NULL) {
@@ -36,18 +38,21 @@ interactiveRectGrob <- function(x=unit(0.5, "npc"), y=unit(0.5, "npc"),
 #' @inheritParams grid::drawDetails
 drawDetails.interactiveRectGrob <- function(x,recording) {
 	rvg_tracer_on()
-	argnames = setdiff( names(x), c("tooltip", "onclick", "data_id") )
+	argnames = setdiff( names(x), c("tooltip", "onclick", "data_id", "use_jquery") )
 	do.call( grid.rect, x[argnames] )
 
 	ids = rvg_tracer_off()
+
+	use_jquery <- x$use_jquery %||% TRUE
+
 	if( length( ids ) > 0 ) {
 
 		if( !is.null( x$tooltip ))
-			send_tooltip(ids, x$tooltip)
+			send_tooltip(ids, x$tooltip, use_jquery)
 		if( !is.null( x$onclick ))
-			send_click(ids, x$onclick)
+			send_click(ids, x$onclick, use_jquery)
 		if( !is.null( x$data_id ))
-			set_data_id(ids, x$data_id)
+			set_data_id(ids, x$data_id, use_jquery)
 	}
 	invisible()
 }

--- a/R/interactiveRectGrob.R
+++ b/R/interactiveRectGrob.R
@@ -25,7 +25,7 @@ interactiveRectGrob <- function(x=unit(0.5, "npc"), y=unit(0.5, "npc"),
 		width <- unit(width, default.units)
 	if (!is.unit(height))
 		height <- unit(height, default.units)
-	grob(tooltip = tooltip, onclick = onclick, data_id = data_id,
+	grob(tooltip = tooltip, onclick = onclick, data_id = data_id, use_jquery = use_jquery,
 			x=x, y=y, width=width, height=height, just=just,
 			hjust=hjust, vjust=vjust,
 			name=name, gp=gp, vp=vp, cl="interactiveRectGrob")

--- a/R/interactiveSegmentsGrob.R
+++ b/R/interactiveSegmentsGrob.R
@@ -6,12 +6,14 @@
 #' @param tooltip tooltip associated with segments
 #' @param onclick javascript action to execute when segment is clicked
 #' @param data_id identifiers to associate with segments
+#' @param use_jquery logical indicating whether to rely on jQuery or not (default: "\code{TRUE}")
 #' @export
 interactiveSegmentsGrob <- function(x0=unit(0, "npc"), y0=unit(0, "npc"),
 		x1=unit(1, "npc"), y1=unit(1, "npc"),
 		tooltip = NULL,
 		onclick = NULL,
 		data_id = NULL,
+		use_jquery = TRUE,
 		default.units="npc",
 		arrow=NULL,
 		name=NULL, gp=gpar(), vp=NULL) {
@@ -24,7 +26,7 @@ interactiveSegmentsGrob <- function(x0=unit(0, "npc"), y0=unit(0, "npc"),
 		y0 <- unit(y0, default.units)
 	if (!is.unit(y1))
 		y1 <- unit(y1, default.units)
-	grob(tooltip = tooltip, onclick = onclick, data_id = data_id,
+	grob(tooltip = tooltip, onclick = onclick, data_id = data_id, use_jquery = use_jquery,
 			x0=x0, y0=y0, x1=x1, y1=y1, arrow=arrow, name=name, gp=gp, vp=vp,
 			cl="interactiveSegmentsGrob")
 }
@@ -35,10 +37,13 @@ interactiveSegmentsGrob <- function(x0=unit(0, "npc"), y0=unit(0, "npc"),
 #' @inheritParams grid::drawDetails
 drawDetails.interactiveSegmentsGrob <- function(x,recording) {
 	rvg_tracer_on()
-	argnames = setdiff( names(x), c("tooltip", "onclick", "data_id") )
+	argnames = setdiff( names(x), c("tooltip", "onclick", "data_id", "use_jquery") )
 	do.call( grid.segments, x[argnames] )
 
 	ids = rvg_tracer_off()
+
+	use_jquery <- x$use_jquery %||% TRUE
+
 	if( length( ids ) > 0 ) {
 
 		if( !is.null( x$tooltip )){
@@ -47,7 +52,7 @@ drawDetails.interactiveSegmentsGrob <- function(x,recording) {
 		  if( length(ids) %% length(x$tooltip) < 1 ){
 		    x$tooltip = rep( x$tooltip, each = length(ids) %/% length(x$tooltip) )
 		  }
-		  send_tooltip(ids, x$tooltip)
+		  send_tooltip(ids, x$tooltip, use_jquery)
 		}
 
 		if( !is.null( x$onclick )){
@@ -56,7 +61,7 @@ drawDetails.interactiveSegmentsGrob <- function(x,recording) {
 		  if( length(ids) %% length(x$onclick) < 1 ){
 		    x$onclick = rep( x$onclick, each = length(ids) %/% length(x$onclick) )
 		  }
-		  send_click(ids, x$onclick)
+		  send_click(ids, x$onclick, use_jquery)
 		}
 		if( !is.null( x$data_id )){
 			if( length( x$data_id ) == 1 && length(ids)>1 )
@@ -64,7 +69,7 @@ drawDetails.interactiveSegmentsGrob <- function(x,recording) {
 			if( length(ids) %% length(x$data_id) < 1 ){
 				x$data_id = rep( x$data_id, each = length(ids) %/% length(x$data_id) )
 			}
-			set_data_id(ids, x$data_id)
+			set_data_id(ids, x$data_id, use_jquery)
 		}
 	}
 	invisible()

--- a/R/interactiveTextGrob.R
+++ b/R/interactiveTextGrob.R
@@ -6,11 +6,13 @@
 #' @param tooltip tooltip associated with rectangles
 #' @param onclick javascript action to execute when rectangle is clicked
 #' @param data_id identifiers to associate with rectangles
+#' @param use_jquery logical indicating whether to rely on jQuery or not (default: "\code{TRUE}")
 #' @export
 interactiveTextGrob <- function(label, x=unit(0.5, "npc"), y=unit(0.5, "npc"),
                                 tooltip = NULL,
                                 onclick = NULL,
                                 data_id = NULL,
+                                use_jquery = TRUE,
                                 just="centre", hjust=NULL, vjust=NULL,
                                 rot=0, check.overlap=FALSE,
                                 default.units="npc",
@@ -19,7 +21,7 @@ interactiveTextGrob <- function(label, x=unit(0.5, "npc"), y=unit(0.5, "npc"),
     x <- unit(x, default.units)
   if (!is.unit(y))
     y <- unit(y, default.units)
-  grob(tooltip = tooltip, onclick = onclick, data_id = data_id,
+  grob(tooltip = tooltip, onclick = onclick, data_id = data_id, use_jquery = use_jquery,
        label=label, x=x, y=y, just=just, hjust=hjust, vjust=vjust,
        rot=rot, check.overlap=check.overlap,
        name=name, gp=gp, vp=vp, cl="interactiveTextGrob")
@@ -32,18 +34,21 @@ interactiveTextGrob <- function(label, x=unit(0.5, "npc"), y=unit(0.5, "npc"),
 #' @inheritParams grid::drawDetails
 drawDetails.interactiveTextGrob <- function(x,recording) {
 	rvg_tracer_on()
-	argnames = setdiff( names(x), c("tooltip", "onclick", "data_id") )
+	argnames = setdiff( names(x), c("tooltip", "onclick", "data_id", "use_jquery") )
 	do.call( grid.text, x[argnames] )
 
 	ids = rvg_tracer_off()
+
+	use_jquery <- x$use_jquery %||% TRUE
+
 	if( length( ids ) > 0 ) {
 
 		if( !is.null( x$tooltip ))
-			send_tooltip(ids, x$tooltip)
+			send_tooltip(ids, x$tooltip, use_jquery)
 		if( !is.null( x$onclick ))
-			send_click(ids, x$onclick)
+			send_click(ids, x$onclick, use_jquery)
 		if( !is.null( x$data_id ))
-			set_data_id(ids, x$data_id)
+			set_data_id(ids, x$data_id, use_jquery)
 	}
 	invisible()
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -43,9 +43,10 @@ rvg_tracer_off <- function(){
 #' @param ids integer vector of graphical elements identifiers (returned by
 #' \code{\link{rvg_tracer_off}}).
 #' @param tooltips tooltip (html is accepted) text.
+#' @param use_jquery logical indicating whether to rely on jQuery or not (default: "\code{TRUE}")
 #'
 #' @export
-send_tooltip = function( ids, tooltips ){
+send_tooltip = function( ids, tooltips, use_jquery=TRUE){
 
 	stopifnot( .Device == "dsvg_device" )
 	if( is.factor(tooltips) )
@@ -55,7 +56,11 @@ send_tooltip = function( ids, tooltips ){
 	stopifnot( is.numeric(ids) )
 	stopifnot( length(ids) == length(tooltips) )
 	dev_num <- as.integer(dev.cur()-1L)
-	add_tooltip(dn = dev_num, id = as.integer( ids ), str = tooltips )
+	if (use_jquery[1] == TRUE) {
+  	add_tooltip(dn = dev_num, id = as.integer( ids ), str = tooltips )
+	} else {
+  	add_tooltip_raw(dn = dev_num, id = as.integer( ids ), str = tooltips )
+	}
 
 	invisible()
 }
@@ -66,9 +71,10 @@ send_tooltip = function( ids, tooltips ){
 #' @param ids integer vector of graphical elements identifiers (returned by
 #' \code{\link{rvg_tracer_off}}).
 #' @param clicks javascript functions to execute on click actions.
+#' @param use_jquery logical indicating whether to rely on jQuery or not (default: "\code{TRUE}")
 #'
 #' @export
-send_click = function( ids, clicks ){
+send_click = function( ids, clicks, use_jquery=TRUE){
 	stopifnot( .Device == "dsvg_device" )
 	if( is.factor(clicks) )
 		clicks = as.character( clicks )
@@ -78,7 +84,11 @@ send_click = function( ids, clicks ){
 	stopifnot( length(ids) == length(clicks) )
 
 	dev_num <- as.integer(dev.cur()-1L)
-	add_click_event(dn = dev_num, id = as.integer( ids ), str = clicks )
+	if (use_jquery[1] == TRUE) {
+  	add_click_event(dn = dev_num, id = as.integer( ids ), str = clicks )
+	} else {
+  	add_click_event_raw(dn = dev_num, id = as.integer( ids ), str = clicks )
+	}
 
 	invisible()
 }
@@ -89,9 +99,10 @@ send_click = function( ids, clicks ){
 #' @param ids integer vector of graphical elements identifiers (returned by
 #' \code{\link{rvg_tracer_off}}).
 #' @param data_id user id to be associated with \code{ids}.
+#' @param use_jquery logical indicating whether to rely on jQuery or not (default: "\code{TRUE}")
 #'
 #' @export
-set_data_id = function( ids, data_id ){
+set_data_id = function( ids, data_id, use_jquery=TRUE){
 	stopifnot( .Device == "dsvg_device" )
 	if( is.factor(data_id) )
 		data_id = as.character( data_id )
@@ -101,7 +112,11 @@ set_data_id = function( ids, data_id ){
 	stopifnot( length(ids) == length(data_id) )
 
 	dev_num <- as.integer(dev.cur()-1L)
-	add_data_id(dn = dev_num, id = as.integer( ids ), data_id = data_id )
+	if (use_jquery[1] == TRUE) {
+  	add_data_id(dn = dev_num, id = as.integer( ids ), data_id = data_id )
+	} else {
+  	add_data_id_raw(dn = dev_num, id = as.integer( ids ), data_id = data_id )
+	}
 
 	invisible()
 }
@@ -130,5 +145,9 @@ read_relationship <- function(filename) {
   out <- list( data = data.frame(id = id, int_id = int_id, type = type, target = target, stringsAsFactors = FALSE ) )
   out$max_int <- max(int_id, na.rm = T)
   out
+}
+
+"%||%" <- function(a, b) {
+  if (!is.null(a)) a else b
 }
 

--- a/man/interactivePointsGrob.Rd
+++ b/man/interactivePointsGrob.Rd
@@ -5,9 +5,9 @@
 \title{Generate interactive grob points}
 \usage{
 interactivePointsGrob(x = unit(0.5, "npc"), y = unit(0.5, "npc"),
-  tooltip = NULL, onclick = NULL, data_id = NULL, pch = 1,
-  size = unit(1, "char"), default.units = "native", name = NULL,
-  gp = gpar(), vp = NULL)
+  tooltip = NULL, onclick = NULL, data_id = NULL, use_jquery = TRUE,
+  pch = 1, size = unit(1, "char"), default.units = "native",
+  name = NULL, gp = gpar(), vp = NULL)
 }
 \arguments{
 \item{x}{numeric vector or unit object specifying x-values.}
@@ -19,6 +19,8 @@ interactivePointsGrob(x = unit(0.5, "npc"), y = unit(0.5, "npc"),
 \item{onclick}{javascript action to execute when point is clicked}
 
 \item{data_id}{identifiers to associate with points}
+
+\item{use_jquery}{logical indicating whether to rely on jQuery or not (default: "\code{TRUE}")}
 
 \item{pch}{numeric or character vector indicating what sort of
     plotting symbol to use.  See \code{\link{points}} for the

--- a/man/interactivePolygonGrob.Rd
+++ b/man/interactivePolygonGrob.Rd
@@ -6,8 +6,8 @@
 \usage{
 interactivePolygonGrob(x = unit(c(0, 1), "npc"), y = unit(c(0, 1), "npc"),
   id = NULL, id.lengths = NULL, tooltip = NULL, onclick = NULL,
-  data_id = NULL, default.units = "npc", name = NULL, gp = gpar(),
-  vp = NULL)
+  data_id = NULL, use_jquery = TRUE, default.units = "npc", name = NULL,
+  gp = gpar(), vp = NULL)
 }
 \arguments{
 \item{x}{A numeric vector or unit object specifying x-locations.}
@@ -27,6 +27,8 @@ interactivePolygonGrob(x = unit(c(0, 1), "npc"), y = unit(c(0, 1), "npc"),
 \item{onclick}{javascript action to execute when polygon is clicked}
 
 \item{data_id}{identifiers to associate with polygons}
+
+\item{use_jquery}{logical indicating whether to rely on jQuery or not (default: "\code{TRUE}")}
 
 \item{default.units}{A string indicating the default units to use
     if \code{x}, \code{y}, \code{width}, or \code{height}

--- a/man/interactivePolylineGrob.Rd
+++ b/man/interactivePolylineGrob.Rd
@@ -6,8 +6,8 @@
 \usage{
 interactivePolylineGrob(x = unit(c(0, 1), "npc"), y = unit(c(0, 1), "npc"),
   id = NULL, id.lengths = NULL, tooltip = NULL, onclick = NULL,
-  data_id = NULL, default.units = "npc", arrow = NULL, name = NULL,
-  gp = gpar(), vp = NULL)
+  data_id = NULL, use_jquery = TRUE, default.units = "npc",
+  arrow = NULL, name = NULL, gp = gpar(), vp = NULL)
 }
 \arguments{
 \item{x}{A numeric vector or unit object specifying x-values.}
@@ -27,6 +27,8 @@ interactivePolylineGrob(x = unit(c(0, 1), "npc"), y = unit(c(0, 1), "npc"),
 \item{onclick}{javascript action to execute when polyline is clicked}
 
 \item{data_id}{identifiers to associate with polylines}
+
+\item{use_jquery}{logical indicating whether to rely on jQuery or not (default: "\code{TRUE}")}
 
 \item{default.units}{A string indicating the default units to use
     if \code{x} or \code{y} are only given as numeric vectors.}

--- a/man/interactiveRectGrob.Rd
+++ b/man/interactiveRectGrob.Rd
@@ -6,9 +6,9 @@
 \usage{
 interactiveRectGrob(x = unit(0.5, "npc"), y = unit(0.5, "npc"),
   width = unit(1, "npc"), height = unit(1, "npc"), tooltip = NULL,
-  onclick = NULL, data_id = NULL, just = "centre", hjust = NULL,
-  vjust = NULL, default.units = "npc", name = NULL, gp = gpar(),
-  vp = NULL)
+  onclick = NULL, data_id = NULL, use_jquery = TRUE, just = "centre",
+  hjust = NULL, vjust = NULL, default.units = "npc", name = NULL,
+  gp = gpar(), vp = NULL)
 }
 \arguments{
 \item{x}{A numeric vector or unit object specifying x-location.}
@@ -24,6 +24,8 @@ interactiveRectGrob(x = unit(0.5, "npc"), y = unit(0.5, "npc"),
 \item{onclick}{javascript action to execute when rectangle is clicked}
 
 \item{data_id}{identifiers to associate with rectangles}
+
+\item{use_jquery}{logical indicating whether to rely on jQuery or not (default: "\code{TRUE}")}
 
 \item{just}{The justification of the rectangle
     relative to its (x, y) location.  If there are two values, the first

--- a/man/interactiveSegmentsGrob.Rd
+++ b/man/interactiveSegmentsGrob.Rd
@@ -6,8 +6,9 @@
 \usage{
 interactiveSegmentsGrob(x0 = unit(0, "npc"), y0 = unit(0, "npc"),
   x1 = unit(1, "npc"), y1 = unit(1, "npc"), tooltip = NULL,
-  onclick = NULL, data_id = NULL, default.units = "npc", arrow = NULL,
-  name = NULL, gp = gpar(), vp = NULL)
+  onclick = NULL, data_id = NULL, use_jquery = TRUE,
+  default.units = "npc", arrow = NULL, name = NULL, gp = gpar(),
+  vp = NULL)
 }
 \arguments{
 \item{x0}{ Numeric indicating the starting x-values of the line segments. }
@@ -25,6 +26,8 @@ interactiveSegmentsGrob(x0 = unit(0, "npc"), y0 = unit(0, "npc"),
 \item{onclick}{javascript action to execute when segment is clicked}
 
 \item{data_id}{identifiers to associate with segments}
+
+\item{use_jquery}{logical indicating whether to rely on jQuery or not (default: "\code{TRUE}")}
 
 \item{default.units}{ A string. }
 

--- a/man/interactiveTextGrob.Rd
+++ b/man/interactiveTextGrob.Rd
@@ -5,9 +5,10 @@
 \title{Generate interactive grob text}
 \usage{
 interactiveTextGrob(label, x = unit(0.5, "npc"), y = unit(0.5, "npc"),
-  tooltip = NULL, onclick = NULL, data_id = NULL, just = "centre",
-  hjust = NULL, vjust = NULL, rot = 0, check.overlap = FALSE,
-  default.units = "npc", name = NULL, gp = gpar(), vp = NULL)
+  tooltip = NULL, onclick = NULL, data_id = NULL, use_jquery = TRUE,
+  just = "centre", hjust = NULL, vjust = NULL, rot = 0,
+  check.overlap = FALSE, default.units = "npc", name = NULL,
+  gp = gpar(), vp = NULL)
 }
 \arguments{
 \item{label}{A character or \link{expression} vector.  Other
@@ -22,6 +23,8 @@ interactiveTextGrob(label, x = unit(0.5, "npc"), y = unit(0.5, "npc"),
 \item{onclick}{javascript action to execute when rectangle is clicked}
 
 \item{data_id}{identifiers to associate with rectangles}
+
+\item{use_jquery}{logical indicating whether to rely on jQuery or not (default: "\code{TRUE}")}
 
 \item{just}{The justification of the text
     relative to its (x, y) location.  If there are two values, the first

--- a/man/send_click.Rd
+++ b/man/send_click.Rd
@@ -4,13 +4,15 @@
 \alias{send_click}
 \title{send click}
 \usage{
-send_click(ids, clicks)
+send_click(ids, clicks, use_jquery = TRUE)
 }
 \arguments{
 \item{ids}{integer vector of graphical elements identifiers (returned by
 \code{\link{rvg_tracer_off}}).}
 
 \item{clicks}{javascript functions to execute on click actions.}
+
+\item{use_jquery}{logical indicating whether to rely on jQuery or not (default: "\code{TRUE}")}
 }
 \description{
 add tooltips on graphical elements.

--- a/man/send_tooltip.Rd
+++ b/man/send_tooltip.Rd
@@ -4,13 +4,15 @@
 \alias{send_tooltip}
 \title{send tooltip}
 \usage{
-send_tooltip(ids, tooltips)
+send_tooltip(ids, tooltips, use_jquery = TRUE)
 }
 \arguments{
 \item{ids}{integer vector of graphical elements identifiers (returned by
 \code{\link{rvg_tracer_off}}).}
 
 \item{tooltips}{tooltip (html is accepted) text.}
+
+\item{use_jquery}{logical indicating whether to rely on jQuery or not (default: "\code{TRUE}")}
 }
 \description{
 add tooltips on graphical elements.

--- a/man/set_data_id.Rd
+++ b/man/set_data_id.Rd
@@ -4,13 +4,15 @@
 \alias{set_data_id}
 \title{add id}
 \usage{
-set_data_id(ids, data_id)
+set_data_id(ids, data_id, use_jquery = TRUE)
 }
 \arguments{
 \item{ids}{integer vector of graphical elements identifiers (returned by
 \code{\link{rvg_tracer_off}}).}
 
 \item{data_id}{user id to be associated with \code{ids}.}
+
+\item{use_jquery}{logical indicating whether to rely on jQuery or not (default: "\code{TRUE}")}
 }
 \description{
 add id to graphical elements.

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -96,6 +96,19 @@ BEGIN_RCPP
     return __result;
 END_RCPP
 }
+// add_tooltip_raw
+bool add_tooltip_raw(int dn, Rcpp::IntegerVector id, std::vector< std::string > str);
+RcppExport SEXP rvg_add_tooltip_raw(SEXP dnSEXP, SEXP idSEXP, SEXP strSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject __result;
+    Rcpp::RNGScope __rngScope;
+    Rcpp::traits::input_parameter< int >::type dn(dnSEXP);
+    Rcpp::traits::input_parameter< Rcpp::IntegerVector >::type id(idSEXP);
+    Rcpp::traits::input_parameter< std::vector< std::string > >::type str(strSEXP);
+    __result = Rcpp::wrap(add_tooltip_raw(dn, id, str));
+    return __result;
+END_RCPP
+}
 // add_click_event
 bool add_click_event(int dn, Rcpp::IntegerVector id, std::vector< std::string > str);
 RcppExport SEXP rvg_add_click_event(SEXP dnSEXP, SEXP idSEXP, SEXP strSEXP) {
@@ -109,6 +122,19 @@ BEGIN_RCPP
     return __result;
 END_RCPP
 }
+// add_click_event_raw
+bool add_click_event_raw(int dn, Rcpp::IntegerVector id, std::vector< std::string > str);
+RcppExport SEXP rvg_add_click_event_raw(SEXP dnSEXP, SEXP idSEXP, SEXP strSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject __result;
+    Rcpp::RNGScope __rngScope;
+    Rcpp::traits::input_parameter< int >::type dn(dnSEXP);
+    Rcpp::traits::input_parameter< Rcpp::IntegerVector >::type id(idSEXP);
+    Rcpp::traits::input_parameter< std::vector< std::string > >::type str(strSEXP);
+    __result = Rcpp::wrap(add_click_event_raw(dn, id, str));
+    return __result;
+END_RCPP
+}
 // add_data_id
 bool add_data_id(int dn, Rcpp::IntegerVector id, std::vector< std::string > data_id);
 RcppExport SEXP rvg_add_data_id(SEXP dnSEXP, SEXP idSEXP, SEXP data_idSEXP) {
@@ -119,6 +145,19 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< Rcpp::IntegerVector >::type id(idSEXP);
     Rcpp::traits::input_parameter< std::vector< std::string > >::type data_id(data_idSEXP);
     __result = Rcpp::wrap(add_data_id(dn, id, data_id));
+    return __result;
+END_RCPP
+}
+// add_data_id_raw
+bool add_data_id_raw(int dn, Rcpp::IntegerVector id, std::vector< std::string > data_id);
+RcppExport SEXP rvg_add_data_id_raw(SEXP dnSEXP, SEXP idSEXP, SEXP data_idSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject __result;
+    Rcpp::RNGScope __rngScope;
+    Rcpp::traits::input_parameter< int >::type dn(dnSEXP);
+    Rcpp::traits::input_parameter< Rcpp::IntegerVector >::type id(idSEXP);
+    Rcpp::traits::input_parameter< std::vector< std::string > >::type data_id(data_idSEXP);
+    __result = Rcpp::wrap(add_data_id_raw(dn, id, data_id));
     return __result;
 END_RCPP
 }

--- a/src/dsvg.cpp
+++ b/src/dsvg.cpp
@@ -601,6 +601,36 @@ bool add_tooltip(int dn, Rcpp::IntegerVector id, std::vector< std::string > str)
   return true;
 }
 
+// [[Rcpp::export]]
+bool add_tooltip_raw(int dn, Rcpp::IntegerVector id, std::vector< std::string > str){
+  int nb_elts = id.size();
+  pGEDevDesc dev= GEgetDevice(dn);
+
+  if (!dev) return false;
+
+  DSVG_dev *svgd = (DSVG_dev *) dev->dev->deviceSpecific;
+
+  fputs("<script type='text/javascript'><![CDATA[", svgd->file);
+
+  for( int i = 0 ; i < nb_elts ; i++ ){
+
+    fprintf(svgd->file,
+            "document.querySelectorAll('#svg_%d')[0].getElementById('%d').setAttribute('data-toggle', 'tooltip');",
+            svgd->canvas_id, id[i]);
+
+    fprintf(svgd->file,
+            "document.querySelectorAll('#svg_%d')[0].getElementById('%d').setAttribute('title', '%s');",
+            svgd->canvas_id, id[i], str[i].c_str());
+
+    fprintf(svgd->file,
+            "document.querySelectorAll('#svg_%d')[0].getElementById('%d').setAttribute('data-html', 'true');",
+            svgd->canvas_id, id[i]);
+
+  }
+  fputs("]]></script>", svgd->file);
+  return true;
+}
+
 
 // [[Rcpp::export]]
 bool add_click_event(int dn, Rcpp::IntegerVector id, std::vector< std::string > str){
@@ -621,6 +651,25 @@ bool add_click_event(int dn, Rcpp::IntegerVector id, std::vector< std::string > 
 }
 
 // [[Rcpp::export]]
+bool add_click_event_raw(int dn, Rcpp::IntegerVector id, std::vector< std::string > str){
+  int nb_elts = id.size();
+  pGEDevDesc dev= GEgetDevice(dn);
+
+  if (!dev) return false;
+
+  DSVG_dev *svgd = (DSVG_dev *) dev->dev->deviceSpecific;
+
+  fputs("<script type='text/javascript'><![CDATA[", svgd->file);
+  for( int i = 0 ; i < nb_elts ; i++ ){
+    fprintf(svgd->file, "document.querySelectorAll('#svg_%d')[0].getElementById('%d').onclick=%s;",
+      svgd->canvas_id, id[i], str[i].c_str() );
+  }
+  fputs("]]></script>", svgd->file);
+  return true;
+}
+
+
+// [[Rcpp::export]]
 bool add_data_id(int dn, Rcpp::IntegerVector id, std::vector< std::string > data_id){
   int nb_elts = id.size();
   pGEDevDesc dev= GEgetDevice(dn);
@@ -632,6 +681,25 @@ bool add_data_id(int dn, Rcpp::IntegerVector id, std::vector< std::string > data
   fputs("<script type='text/javascript'><![CDATA[", svgd->file);
   for( int i = 0 ; i < nb_elts ; i++ ){
     fprintf(svgd->file, "$('#svg_%d').find('#%d').attr('data-id','%s');",
+      svgd->canvas_id, id[i], data_id[i].c_str() );
+  }
+  fputs("]]></script>", svgd->file);
+  return true;
+}
+
+
+// [[Rcpp::export]]
+bool add_data_id_raw(int dn, Rcpp::IntegerVector id, std::vector< std::string > data_id){
+  int nb_elts = id.size();
+  pGEDevDesc dev= GEgetDevice(dn);
+
+  if (!dev) return false;
+
+  DSVG_dev *svgd = (DSVG_dev *) dev->dev->deviceSpecific;
+
+  fputs("<script type='text/javascript'><![CDATA[", svgd->file);
+  for( int i = 0 ; i < nb_elts ; i++ ){
+    fprintf(svgd->file, "document.querySelectorAll('#svg_%d')[0].getElementById('%d').setAttribute('data-id','%s');",
       svgd->canvas_id, id[i], data_id[i].c_str() );
   }
   fputs("]]></script>", svgd->file);

--- a/tests/testthat/test-svg-interactive.R
+++ b/tests/testthat/test-svg-interactive.R
@@ -38,6 +38,25 @@ test_that("tooltips are written", {
   expect_true( grepl( tip2, script_txt ) )
 })
 
+test_that("tooltips are written without jQuery", {
+  file <- tempfile(fileext = ".svg")
+  dsvg( file = file, standalone = FALSE, canvas_id = 1 )
+  plot.new()
+  rvg_tracer_on()
+  points(c(0.5, .6), c(.4, .3))
+  ids = rvg_tracer_off()
+  send_tooltip(ids = ids, tooltips = c("tip1", "tip2"), use_jquery=FALSE)
+  dev.off()
+
+  doc <- read_xml(file)
+  script_node <- xml_find_one(doc, ".//script")
+  script_txt <-  xml_text(script_node)
+  tip1 <- "setAttribute\\(\\'title\\', \\'tip1\\'\\)"
+  tip2 <- "setAttribute\\(\\'title\\', \\'tip2\\'\\)"
+  expect_true( grepl( tip1, script_txt ) )
+  expect_true( grepl( tip2, script_txt ) )
+})
+
 test_that("ID are written", {
   file <- tempfile(fileext = ".svg")
   dsvg( file = file, standalone = FALSE, canvas_id = 1 )
@@ -57,6 +76,25 @@ test_that("ID are written", {
   expect_true( grepl( tip2, script_txt ) )
 })
 
+
+test_that("ID are written without jQuery", {
+  file <- tempfile(fileext = ".svg")
+  dsvg( file = file, standalone = FALSE, canvas_id = 1 )
+  plot.new()
+  rvg_tracer_on()
+  points(c(0.5, .6), c(.4, .3))
+  ids = rvg_tracer_off()
+  set_data_id(ids = ids, data_id = c("HI1", "HI2") , use_jquery = FALSE)
+  dev.off()
+
+  doc <- read_xml(file)
+  script_node <- xml_find_one(doc, ".//script")
+  script_txt <-  xml_text(script_node)
+  tip1 <- "setAttribute\\(\\'data-id\\',\\'HI1\\'\\)"
+  tip2 <- "setAttribute\\(\\'data-id\\',\\'HI2\\'\\)"
+  expect_true( grepl( tip1, script_txt ) )
+  expect_true( grepl( tip2, script_txt ) )
+})
 
 test_that("clicks are written", {
   file <- tempfile(fileext = ".svg")
@@ -78,6 +116,25 @@ test_that("clicks are written", {
 })
 
 
+test_that("clicks are written without jQuery", {
+  file <- tempfile(fileext = ".svg")
+  dsvg( file = file, standalone = FALSE, canvas_id = 1 )
+  plot.new()
+  rvg_tracer_on()
+  points(c(0.5, .6), c(.4, .3))
+  ids = rvg_tracer_off()
+  send_click(ids = ids, clicks = c("alert(1)", "alert(2)"), use_jquery = FALSE)
+  dev.off()
+
+  doc <- read_xml(file)
+  script_node <- xml_find_one(doc, ".//script")
+  script_txt <-  xml_text(script_node)
+  tip1 <- "onclick=alert\\(1\\)"
+  tip2 <- "onclick=alert\\(2\\)"
+  expect_true( grepl( tip1, script_txt ) )
+  expect_true( grepl( tip2, script_txt ) )
+})
+
 test_that("interactive grid point grobs", {
   file <- tempfile(fileext = ".svg")
   dsvg( file = file, standalone = FALSE, canvas_id = 1 )
@@ -90,6 +147,21 @@ test_that("interactive grid point grobs", {
   script_node <- xml_find_one(doc, ".//script")
   script_txt <-  xml_text(script_node)
   tip <- "attr\\(\\'title\\',\\'tooltip\\'\\)"
+  expect_true( grepl( tip, script_txt ) )
+})
+
+test_that("interactive grid point grobs without jQuery", {
+  file <- tempfile(fileext = ".svg")
+  dsvg( file = file, standalone = FALSE, canvas_id = 1 )
+  gl <- interactivePointsGrob(tooltip = "tooltip", use_jquery = FALSE)
+  gl <- editGrob(gl, gp = gpar(col = "green"))
+  grid.draw(gl)
+  dev.off()
+
+  doc <- read_xml(file)
+  script_node <- xml_find_one(doc, ".//script")
+  script_txt <-  xml_text(script_node)
+  tip <- "setAttribute\\(\\'title\\', \\'tooltip\\'\\)"
   expect_true( grepl( tip, script_txt ) )
 })
 
@@ -110,6 +182,22 @@ test_that("interactive grid polygon grobs", {
 })
 
 
+test_that("interactive grid polygon grobs without jQuery", {
+  file <- tempfile(fileext = ".svg")
+  dsvg( file = file, standalone = FALSE, canvas_id = 1 )
+  gl <- interactivePolygonGrob(x=c(0, 0.5, 1, 0.5), y=c(0.5, 1, 0.5, 0),
+                               tooltip = "tooltip", use_jquery = FALSE)
+  gl <- editGrob(gl, gp = gpar(col = "green"))
+  grid.draw(gl)
+  dev.off()
+
+  doc <- read_xml(file)
+  script_node <- xml_find_one(doc, ".//script")
+  script_txt <-  xml_text(script_node)
+  tip <- "setAttribute\\(\\'title\\', \\'tooltip\\'\\)"
+  expect_true( grepl( tip, script_txt ) )
+})
+
 test_that("interactive grid polyline grobs", {
   file <- tempfile(fileext = ".svg")
   dsvg( file = file, standalone = FALSE, canvas_id = 1 )
@@ -127,6 +215,22 @@ test_that("interactive grid polyline grobs", {
 })
 
 
+test_that("interactive grid polyline grobs without jQuery", {
+  file <- tempfile(fileext = ".svg")
+  dsvg( file = file, standalone = FALSE, canvas_id = 1 )
+  gl <- interactivePolylineGrob(x=c(0, 0.5, 1, 0.5), y=c(0.5, 1, 0.5, 0),
+                               tooltip = "tooltip", use_jquery = FALSE)
+  gl <- editGrob(gl, gp = gpar(col = "blue"))
+  grid.draw(gl)
+  dev.off()
+
+  doc <- read_xml(file)
+  script_node <- xml_find_one(doc, ".//script")
+  script_txt <-  xml_text(script_node)
+  tip <- "setAttribute\\(\\'title\\', \\'tooltip\\'\\)"
+  expect_true( grepl( tip, script_txt ) )
+})
+
 test_that("interactive grid rect grobs", {
   file <- tempfile(fileext = ".svg")
   dsvg( file = file, standalone = FALSE, canvas_id = 1 )
@@ -143,6 +247,21 @@ test_that("interactive grid rect grobs", {
 })
 
 
+test_that("interactive grid rect grobs without jQuery", {
+  file <- tempfile(fileext = ".svg")
+  dsvg( file = file, standalone = FALSE, canvas_id = 1 )
+  gl <- interactiveRectGrob(tooltip = "tooltip", use_jquery = FALSE)
+  gl <- editGrob(gl, gp = gpar(col = "blue"))
+  grid.draw(gl)
+  dev.off()
+
+  doc <- read_xml(file)
+  script_node <- xml_find_one(doc, ".//script")
+  script_txt <-  xml_text(script_node)
+  tip <- "setAttribute\\(\\'title\\', \\'tooltip\\'\\)"
+  expect_true( grepl( tip, script_txt ) )
+})
+
 test_that("interactive grid segment grobs", {
   file <- tempfile(fileext = ".svg")
   dsvg( file = file, standalone = FALSE, canvas_id = 1 )
@@ -158,6 +277,21 @@ test_that("interactive grid segment grobs", {
   expect_true( grepl( tip, script_txt ) )
 })
 
+test_that("interactive grid segment grobs without jQuery", {
+  file <- tempfile(fileext = ".svg")
+  dsvg( file = file, standalone = FALSE, canvas_id = 1 )
+  gl <- interactiveSegmentsGrob(tooltip = "tooltip", use_jquery = FALSE)
+  gl <- editGrob(gl)
+  grid.draw(gl)
+  dev.off()
+
+  doc <- read_xml(file)
+  script_node <- xml_find_one(doc, ".//script")
+  script_txt <-  xml_text(script_node)
+  tip <- "setAttribute\\(\\'title\\', \\'tooltip\\'\\)"
+  expect_true( grepl( tip, script_txt ) )
+})
+
 test_that("interactive grid text grobs", {
   file <- tempfile(fileext = ".svg")
   dsvg( file = file, standalone = FALSE, canvas_id = 1 )
@@ -170,6 +304,22 @@ test_that("interactive grid text grobs", {
   script_node <- xml_find_one(doc, ".//script")
   script_txt <-  xml_text(script_node)
   tip <- "attr\\(\\'title\\',\\'tooltip\\'\\)"
+  expect_true( grepl( tip, script_txt ) )
+})
+
+
+test_that("interactive grid text grobs without jQuery", {
+  file <- tempfile(fileext = ".svg")
+  dsvg( file = file, standalone = FALSE, canvas_id = 1 )
+  gl <- interactiveTextGrob(label = "text", tooltip = "tooltip", use_jquery = FALSE)
+  gl <- editGrob(gl)
+  grid.draw(gl)
+  dev.off()
+
+  doc <- read_xml(file)
+  script_node <- xml_find_one(doc, ".//script")
+  script_txt <-  xml_text(script_node)
+  tip <- "setAttribute\\(\\'title\\', \\'tooltip\\'\\)"
   expect_true( grepl( tip, script_txt ) )
 })
 


### PR DESCRIPTION
I added "`_raw`" functions in `dsvg.cpp` and a `use_jquery` parameter (defaulting to `TRUE`) to `send_tooltip`, `send_click` and `send_data_id` to enable setting of data attributes and other attributes without jQuery. I also added _"without jQuery"_ equivalent tests to the test harness and made initial changes to a local copy of `ggiraph` to see how well it works (and it works well :-)

This lays the groundwork for making a jQuery-independent widget in `ggiraph`. 
