### PR TITLE
Use xml2::xml_find_first() instead of deprecated xml2::xml_find_one()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,6 +29,8 @@ Suggests:
     testthat,
     covr,
     grid
+Remotes:
+    hadley/xml2
 URL: https://github.com/davidgohel/rvg
 BugReports: https://github.com/davidgohel/rvg/issues
 RoxygenNote: 5.0.1

--- a/tests/testthat/test-bg.R
+++ b/tests/testthat/test-bg.R
@@ -10,14 +10,14 @@ test_that("pptx background exists if background is not transparent", {
 
 
   doc <- read_xml(file)
-  solid_fill <- try( xml_find_one(doc, ".//p:sp/p:spPr/a:solidFill", ns = xml_ns( doc )), silent = FALSE )
+  solid_fill <- try( xml_find_first(doc, ".//p:sp/p:spPr/a:solidFill", ns = xml_ns( doc )), silent = FALSE )
   expect_is(object = solid_fill, class = "xml_node")
 
-  color_node <- xml_find_one(doc, ".//p:sp/p:spPr/a:solidFill/a:srgbClr", ns = xml_ns( doc ))
+  color_node <- xml_find_first(doc, ".//p:sp/p:spPr/a:solidFill/a:srgbClr", ns = xml_ns( doc ))
   color <- xml_attr(color_node, "val")
   expect_equal(object = color, expected = "123456")
 
-  alpha_node <- xml_find_one(doc, ".//p:sp/p:spPr/a:solidFill/a:srgbClr/a:alpha", ns = xml_ns( doc ))
+  alpha_node <- xml_find_first(doc, ".//p:sp/p:spPr/a:solidFill/a:srgbClr/a:alpha", ns = xml_ns( doc ))
   alpha <- xml_attr(alpha_node, "val")
   expect_equal(object = alpha, expected = "100000")
 
@@ -27,7 +27,7 @@ test_that("pptx background exists if background is not transparent", {
   dev.off()
 
   doc <- read_xml(file)
-  alpha_node <- xml_find_one(doc, ".//p:sp/p:spPr/a:solidFill/a:srgbClr/a:alpha", ns = xml_ns( doc ))
+  alpha_node <- xml_find_first(doc, ".//p:sp/p:spPr/a:solidFill/a:srgbClr/a:alpha", ns = xml_ns( doc ))
   alpha <- xml_attr(alpha_node, "val")
   expect_equal(object = alpha, expected = "60000")
 
@@ -42,7 +42,7 @@ test_that("pptx background does not exist if background is transparent", {
   dev.off()
 
   doc <- read_xml(file)
-  bg_node <- try( xml_find_one(doc, ".//p:sp", ns = xml_ns( doc )), silent = TRUE )
+  bg_node <- try( xml_find_first(doc, ".//p:sp", ns = xml_ns( doc )), silent = TRUE )
   expect_true( inherits(bg_node, "try-error") )
 })
 
@@ -56,14 +56,14 @@ test_that("docx background exists if background is not transparent", {
 
 
   doc <- read_xml(file)
-  solid_fill <- try( xml_find_one(doc, ".//wps:wsp/wps:spPr/a:solidFill", ns = xml_ns( doc )), silent = FALSE )
+  solid_fill <- try( xml_find_first(doc, ".//wps:wsp/wps:spPr/a:solidFill", ns = xml_ns( doc )), silent = FALSE )
   expect_is(object = solid_fill, class = "xml_node")
 
-  color_node <- xml_find_one(doc, ".//wps:wsp/wps:spPr/a:solidFill/a:srgbClr", ns = xml_ns( doc ))
+  color_node <- xml_find_first(doc, ".//wps:wsp/wps:spPr/a:solidFill/a:srgbClr", ns = xml_ns( doc ))
   color <- xml_attr(color_node, "val")
   expect_equal(object = color, expected = "123456")
 
-  alpha_node <- xml_find_one(doc, ".//wps:wsp/wps:spPr/a:solidFill/a:srgbClr/a:alpha", ns = xml_ns( doc ))
+  alpha_node <- xml_find_first(doc, ".//wps:wsp/wps:spPr/a:solidFill/a:srgbClr/a:alpha", ns = xml_ns( doc ))
   alpha <- xml_attr(alpha_node, "val")
   expect_equal(object = alpha, expected = "100000")
 
@@ -73,7 +73,7 @@ test_that("docx background exists if background is not transparent", {
   dev.off()
 
   doc <- read_xml(file)
-  alpha_node <- xml_find_one(doc, ".//wps:wsp/wps:spPr/a:solidFill/a:srgbClr/a:alpha", ns = xml_ns( doc ))
+  alpha_node <- xml_find_first(doc, ".//wps:wsp/wps:spPr/a:solidFill/a:srgbClr/a:alpha", ns = xml_ns( doc ))
   alpha <- xml_attr(alpha_node, "val")
   expect_equal(object = alpha, expected = "60000")
 })
@@ -87,7 +87,7 @@ test_that("docx background does not exist if background is transparent", {
   dev.off()
 
   doc <- read_xml(file)
-  bg_node <- try( xml_find_one(doc, ".//wps:wsp", ns = xml_ns( doc )), silent = TRUE )
+  bg_node <- try( xml_find_first(doc, ".//wps:wsp", ns = xml_ns( doc )), silent = TRUE )
   expect_true( inherits(bg_node, "try-error") )
 })
 
@@ -101,7 +101,7 @@ test_that("svg background exists if background is not transparent", {
   dev.off()
 
   doc <- read_xml(file)
-  bg_node <- try( xml_find_one(doc, ".//rect[@id]"), silent = FALSE )
+  bg_node <- try( xml_find_first(doc, ".//rect[@id]"), silent = FALSE )
   expect_is(object = bg_node, class = "xml_node")
   expect_equal(object = xml_attr(bg_node, "fill"), expected = "#123456")
   expect_equal(object = xml_attr(bg_node, "fill-opacity"), expected = "1")
@@ -112,7 +112,7 @@ test_that("svg background exists if background is not transparent", {
   dev.off()
 
   doc <- read_xml(file)
-  bg_node <- try( xml_find_one(doc, ".//rect[@id]"), silent = FALSE )
+  bg_node <- try( xml_find_first(doc, ".//rect[@id]"), silent = FALSE )
   expect_equal(object = xml_attr(bg_node, "fill-opacity"), expected = "0.6")
 })
 
@@ -125,7 +125,7 @@ test_that("svg background does not exist if background is transparent", {
   dev.off()
 
   doc <- read_xml(file)
-  bg_node <- try( xml_find_one(doc, ".//rect[@id]"), silent = TRUE )
+  bg_node <- try( xml_find_first(doc, ".//rect[@id]"), silent = TRUE )
   expect_true( inherits(bg_node, "try-error") )
 })
 

--- a/tests/testthat/test-dml-editable.R
+++ b/tests/testthat/test-dml-editable.R
@@ -11,7 +11,7 @@ test_that("check docx editable properties", {
 
   x <- read_xml(file)
   xpath_ <- ".//wps:wsp/wps:cNvSpPr/a:spLocks"
-  node <- try( xml_find_one(x, xpath_, ns = xml_ns( x )), silent = TRUE )
+  node <- try( xml_find_first(x, xpath_, ns = xml_ns( x )), silent = TRUE )
   expect_is(object = node, class = "xml_node")
 
   file <- tempfile()
@@ -21,7 +21,7 @@ test_that("check docx editable properties", {
   dev.off()
   x <- read_xml(file)
   xpath_ <- ".//wps:wsp/wps:cNvSpPr/a:spLocks"
-  expect_error(object = xml_find_one(x, xpath_, ns = xml_ns( x )), regexp = "No matches")
+  expect_error(object = xml_find_first(x, xpath_, ns = xml_ns( x )), regexp = "No matches")
 })
 
 test_that("check pptx editable properties", {
@@ -34,7 +34,7 @@ test_that("check pptx editable properties", {
 
   x <- read_xml(file)
   xpath_ <- ".//p:sp/p:nvSpPr/p:cNvSpPr/a:spLocks"
-  node <- try( xml_find_one(x, xpath_, ns = xml_ns( x )), silent = TRUE )
+  node <- try( xml_find_first(x, xpath_, ns = xml_ns( x )), silent = TRUE )
   expect_is(object = node, class = "xml_node")
 
   file <- tempfile()
@@ -44,7 +44,7 @@ test_that("check pptx editable properties", {
   dev.off()
   x <- read_xml(file)
   xpath_ <- ".//p:sp/p:nvSpPr/p:cNvSpPr/a:spLocks"
-  expect_error(object = xml_find_one(x, xpath_, ns = xml_ns( x )), regexp = "No matches")
+  expect_error(object = xml_find_first(x, xpath_, ns = xml_ns( x )), regexp = "No matches")
 })
 
 
@@ -58,7 +58,7 @@ test_that("check xlsx editable properties", {
 
   x <- read_xml(file)
   xpath_ <- ".//xdr:sp/xdr:nvSpPr/xdr:cNvSpPr/a:spLocks"
-  node <- try( xml_find_one(x, xpath_, ns = xml_ns( x )), silent = TRUE )
+  node <- try( xml_find_first(x, xpath_, ns = xml_ns( x )), silent = TRUE )
   expect_is(object = node, class = "xml_node")
 
   file <- tempfile()
@@ -68,5 +68,5 @@ test_that("check xlsx editable properties", {
   dev.off()
   x <- read_xml(file)
   xpath_ <- ".//xdr:sp/xdr:nvSpPr/xdr:cNvSpPr/a:spLocks"
-  expect_error(object = xml_find_one(x, xpath_, ns = xml_ns( x )), regexp = "No matches")
+  expect_error(object = xml_find_first(x, xpath_, ns = xml_ns( x )), regexp = "No matches")
 })

--- a/tests/testthat/test-docx-lines.R
+++ b/tests/testthat/test-docx-lines.R
@@ -10,7 +10,7 @@ test_that("segments don't have fill", {
   dev.off()
 
   doc <- read_xml(file)
-  fill_node <- try(xml_find_one(doc, ".//wps:wsp/wps:spPr/a:solidFill", ns = xml_ns( doc ) ), silent = TRUE )
+  fill_node <- try(xml_find_first(doc, ".//wps:wsp/wps:spPr/a:solidFill", ns = xml_ns( doc ) ), silent = TRUE )
   expect_true( inherits(fill_node, "try-error") )
 })
 
@@ -23,7 +23,7 @@ test_that("lines don't have fill", {
   dev.off()
 
   doc <- read_xml(file)
-  fill_node <- try(xml_find_one(doc, ".//wps:wsp/wps:spPr/a:solidFill", ns = xml_ns( doc ) ), silent = TRUE )
+  fill_node <- try(xml_find_first(doc, ".//wps:wsp/wps:spPr/a:solidFill", ns = xml_ns( doc ) ), silent = TRUE )
   expect_true( inherits(fill_node, "try-error") )
 })
 
@@ -35,7 +35,7 @@ test_that("polygons do have fill", {
   dev.off()
 
   doc <- read_xml(file)
-  fill_node <- try(xml_find_one(doc, ".//wps:wsp/wps:spPr/a:solidFill", ns = xml_ns( doc ) ), silent = TRUE )
+  fill_node <- try(xml_find_first(doc, ".//wps:wsp/wps:spPr/a:solidFill", ns = xml_ns( doc ) ), silent = TRUE )
   expect_false( inherits(fill_node, "try-error") )
 })
 
@@ -49,11 +49,11 @@ test_that("polygons without border", {
   doc <- read_xml(file)
 
   # Have fill
-  fill_color <- try(xml_find_one(doc, ".//wps:wsp/wps:spPr/a:solidFill/a:srgbClr", ns = xml_ns( doc ) ), silent = TRUE )
+  fill_color <- try(xml_find_first(doc, ".//wps:wsp/wps:spPr/a:solidFill/a:srgbClr", ns = xml_ns( doc ) ), silent = TRUE )
   expect_equal(xml_attr(fill_color, "val"), "FF0000")
 
   # Have no ln
-  line_color <- try( xml_find_one(doc, ".//wps:wsp/wps:spPr/a:ln", ns = xml_ns( doc )), silent = TRUE )
+  line_color <- try( xml_find_first(doc, ".//wps:wsp/wps:spPr/a:ln", ns = xml_ns( doc )), silent = TRUE )
   expect_true( inherits(line_color, "try-error") )
 
 })
@@ -65,7 +65,7 @@ dash_array <- function(...) {
   dev.off()
 
   doc <- read_xml(file)
-  dash <- try(xml_find_one(doc, ".//wps:wsp/wps:spPr/a:ln/a:prstDash", ns = xml_ns( doc )), silent = TRUE )
+  dash <- try(xml_find_first(doc, ".//wps:wsp/wps:spPr/a:ln/a:prstDash", ns = xml_ns( doc )), silent = TRUE )
   dash
 }
 custom_dash_array <- function(...) {
@@ -104,7 +104,7 @@ test_that("line join shapes", {
   dev.off()
 
   doc <- read_xml(file)
-  join_shape <- try(xml_find_one(doc, ".//wps:wsp/wps:spPr/a:ln/a:round", ns = xml_ns( doc ) ), silent = TRUE )
+  join_shape <- try(xml_find_first(doc, ".//wps:wsp/wps:spPr/a:ln/a:round", ns = xml_ns( doc ) ), silent = TRUE )
   expect_false( inherits(join_shape, "try-error") )
 
   file <- tempfile()
@@ -114,7 +114,7 @@ test_that("line join shapes", {
   dev.off()
 
   doc <- read_xml(file)
-  join_shape <- try(xml_find_one(doc, ".//wps:wsp/wps:spPr/a:ln/a:miter", ns = xml_ns( doc ) ), silent = TRUE )
+  join_shape <- try(xml_find_first(doc, ".//wps:wsp/wps:spPr/a:ln/a:miter", ns = xml_ns( doc ) ), silent = TRUE )
   expect_false( inherits(join_shape, "try-error") )
 
   file <- tempfile()
@@ -124,6 +124,6 @@ test_that("line join shapes", {
   dev.off()
 
   doc <- read_xml(file)
-  join_shape <- try(xml_find_one(doc, ".//wps:wsp/wps:spPr/a:ln/a:bevel", ns = xml_ns( doc ) ), silent = TRUE )
+  join_shape <- try(xml_find_first(doc, ".//wps:wsp/wps:spPr/a:ln/a:bevel", ns = xml_ns( doc ) ), silent = TRUE )
   expect_false( inherits(join_shape, "try-error") )
 })

--- a/tests/testthat/test-docx-raster.R
+++ b/tests/testthat/test-docx-raster.R
@@ -60,10 +60,10 @@ test_that("pic tag can be found", {
 
 
   doc <- read_xml(file)
-  pic_node <- try( xml_find_one(doc, ".//a:blipFill", ns = xml_ns( doc )), silent = TRUE )
+  pic_node <- try( xml_find_first(doc, ".//a:blipFill", ns = xml_ns( doc )), silent = TRUE )
   expect_false( inherits(pic_node, "try-error") )
 
-  blip_node <- try( xml_find_one(pic_node, ".//a:blip", ns = xml_ns( doc )), silent = TRUE )
+  blip_node <- try( xml_find_first(pic_node, ".//a:blip", ns = xml_ns( doc )), silent = TRUE )
   expect_false( inherits(blip_node, "try-error") )
 })
 

--- a/tests/testthat/test-docx-text.R
+++ b/tests/testthat/test-docx-text.R
@@ -11,7 +11,7 @@ test_that("text can be found", {
 
   x <- read_xml(file)
   xpath_ <- ".//wps:wsp/wps:txbx/w:txbxContent/w:p/w:r/w:t"
-  text_node <- xml_find_one(x, xpath_, ns = xml_ns( x ))
+  text_node <- xml_find_first(x, xpath_, ns = xml_ns( x ))
   expect_is(object = text_node, class = "xml_node")
   expect_equal(xml_text(text_node), "hello")
 })
@@ -50,7 +50,7 @@ test_that("special characters are escaped", {
   x <- read_xml(file)
   ns <-  xml_ns( x )
   xpath_ <- ".//wps:wsp/wps:txbx/w:txbxContent/w:p/w:r/w:t"
-  text_node <- xml_find_one(x, xpath_, ns = xml_ns( x ))
+  text_node <- xml_find_first(x, xpath_, ns = xml_ns( x ))
   expect_equal(xml_text(text_node), "<&>")
 })
 
@@ -66,7 +66,7 @@ test_that("utf-8 characters are preserved", {
   x <- read_xml(file)
   ns <-  xml_ns( x )
   xpath_ <- ".//wps:wsp/wps:txbx/w:txbxContent/w:p/w:r/w:t"
-  text_node <- xml_find_one(x, xpath_, ns = xml_ns( x ))
+  text_node <- xml_find_first(x, xpath_, ns = xml_ns( x ))
   expect_equal(xml_text(text_node), "\u00b5")
 })
 
@@ -80,7 +80,7 @@ test_that("text color is written in fill attr", {
   x <- read_xml(file)
   ns <-  xml_ns( x )
   xpath_ <- ".//wps:wsp/wps:txbx/w:txbxContent/w:p/w:r/w:rPr/w:color"
-  selected_node <- xml_find_one(x, xpath_, ns = xml_ns( x ))
+  selected_node <- xml_find_first(x, xpath_, ns = xml_ns( x ))
   expect_equal(xml_attr(selected_node, "val"), "113399")
 })
 
@@ -95,10 +95,10 @@ test_that("default point size is 12", {
   ns <-  xml_ns( x )
   xpath_ <- ".//wps:wsp/wps:txbx/w:txbxContent/w:p/w:r/w:rPr/w:sz"
 
-  selected_node <- xml_find_one(x, xpath_, ns = xml_ns( x ))
+  selected_node <- xml_find_first(x, xpath_, ns = xml_ns( x ))
   expect_equal(xml_attr(selected_node, "val"), "24")
   xpath_ <- ".//wps:wsp/wps:txbx/w:txbxContent/w:p/w:r/w:rPr/w:szCs"
-  selected_node <- xml_find_one(x, xpath_, ns = xml_ns( x ))
+  selected_node <- xml_find_first(x, xpath_, ns = xml_ns( x ))
   expect_equal(xml_attr(selected_node, "val"), "24")
 })
 
@@ -112,7 +112,7 @@ test_that("cex does not generate fractional font sizes", {
   x <- read_xml(file)
   ns <-  xml_ns( x )
   xpath_ <- ".//wps:wsp/wps:txbx/w:txbxContent/w:p/w:r/w:rPr/w:sz"
-  selected_node <- xml_find_one(x, xpath_, ns = xml_ns( x ))
+  selected_node <- xml_find_first(x, xpath_, ns = xml_ns( x ))
   expect_equal(xml_attr(selected_node, "val"), "6")
 })
 
@@ -128,9 +128,9 @@ test_that("font sets weight/style", {
   xpath_b <- ".//wps:wsp/wps:txbx/w:txbxContent/w:p/w:r/w:rPr/w:b"
   xpath_i <- ".//wps:wsp/wps:txbx/w:txbxContent/w:p/w:r/w:rPr/w:i"
 
-  selected_node <- try( xml_find_one(x, xpath_b, ns = xml_ns( x )), silent = TRUE)
+  selected_node <- try( xml_find_first(x, xpath_b, ns = xml_ns( x )), silent = TRUE)
   expect_is(selected_node, "try-error")
-  selected_node <- try( xml_find_one(x, xpath_i, ns = xml_ns( x )), silent = TRUE)
+  selected_node <- try( xml_find_first(x, xpath_i, ns = xml_ns( x )), silent = TRUE)
   expect_is(selected_node, "try-error")
 
   file <- tempfile()
@@ -142,10 +142,10 @@ test_that("font sets weight/style", {
   x <- read_xml(file)
   ns <-  xml_ns( x )
   selected_node <- try(
-    xml_find_one(x, xpath_b, ns = xml_ns( x )), silent = TRUE)
+    xml_find_first(x, xpath_b, ns = xml_ns( x )), silent = TRUE)
   expect_is(selected_node, "xml_node")
   selected_node <- try(
-    xml_find_one(x, xpath_i, ns = xml_ns( x )), silent = TRUE)
+    xml_find_first(x, xpath_i, ns = xml_ns( x )), silent = TRUE)
   expect_is(selected_node, "try-error")
 
   file <- tempfile()
@@ -156,9 +156,9 @@ test_that("font sets weight/style", {
 
   x <- read_xml(file)
   ns <-  xml_ns( x )
-  selected_node <- try( xml_find_one(x, xpath_b, ns = xml_ns( x )), silent = TRUE)
+  selected_node <- try( xml_find_first(x, xpath_b, ns = xml_ns( x )), silent = TRUE)
   expect_is(selected_node, "try-error")
-  selected_node <- try( xml_find_one(x, xpath_i, ns = xml_ns( x )), silent = TRUE)
+  selected_node <- try( xml_find_first(x, xpath_i, ns = xml_ns( x )), silent = TRUE)
   expect_is(selected_node, "xml_node")
 
   file <- tempfile()
@@ -169,9 +169,9 @@ test_that("font sets weight/style", {
 
   x <- read_xml(file)
   ns <-  xml_ns( x )
-  selected_node <- try( xml_find_one(x, xpath_b, ns = xml_ns( x )), silent = TRUE)
+  selected_node <- try( xml_find_first(x, xpath_b, ns = xml_ns( x )), silent = TRUE)
   expect_is(selected_node, "xml_node")
-  selected_node <- try( xml_find_one(x, xpath_i, ns = xml_ns( x )), silent = TRUE)
+  selected_node <- try( xml_find_first(x, xpath_i, ns = xml_ns( x )), silent = TRUE)
   expect_is(selected_node, "xml_node")
 })
 
@@ -220,7 +220,7 @@ test_that("symbol font family is 'Symbol'", {
   x <- read_xml(file)
   ns <-  xml_ns( x )
   xpath_ <- ".//wps:wsp/wps:txbx/w:txbxContent/w:p/w:r/w:rPr/w:rFonts"
-  font_node <- xml_find_one(x, xpath_, ns = xml_ns( x ))
+  font_node <- xml_find_first(x, xpath_, ns = xml_ns( x ))
   expect_equal(xml_attr(font_node, "ascii"), "Symbol")
   expect_equal(xml_attr(font_node, "hAnsi"), "Symbol")
   expect_equal(xml_attr(font_node, "cs"), "Symbol")

--- a/tests/testthat/test-docx-xfrm.R
+++ b/tests/testthat/test-docx-xfrm.R
@@ -12,16 +12,16 @@ test_that("rect has dimensions", {
 
 
   doc <- read_xml(file)
-  xfrm_node <- xml_find_one(doc, ".//wps:wsp/wps:spPr/a:xfrm", ns = xml_ns( doc ))
+  xfrm_node <- xml_find_first(doc, ".//wps:wsp/wps:spPr/a:xfrm", ns = xml_ns( doc ))
   expect_is(object = xfrm_node, class = "xml_node")
 
-  off_node <- xml_find_one(doc, ".//wps:wsp/wps:spPr/a:xfrm/a:off", ns = xml_ns( doc ))
+  off_node <- xml_find_first(doc, ".//wps:wsp/wps:spPr/a:xfrm/a:off", ns = xml_ns( doc ))
   offx <- xml_attr(off_node, "x")
   offy <- xml_attr(off_node, "y")
   expect_true( grepl("^[0-9]+$", offx ) )
   expect_true( grepl("^[0-9]+$", offy ) )
 
-  ext_node <- xml_find_one(doc, ".//wps:wsp/wps:spPr/a:xfrm/a:ext", ns = xml_ns( doc ))
+  ext_node <- xml_find_first(doc, ".//wps:wsp/wps:spPr/a:xfrm/a:ext", ns = xml_ns( doc ))
   cx <- xml_attr(ext_node, "cx")
   cy <- xml_attr(ext_node, "cy")
   expect_true( grepl("^[0-9]+$", cx ) )
@@ -39,16 +39,16 @@ test_that("lines has dimensions", {
 
 
   doc <- read_xml(file)
-  xfrm_node <- xml_find_one(doc, ".//wps:wsp/wps:spPr/a:xfrm", ns = xml_ns( doc ))
+  xfrm_node <- xml_find_first(doc, ".//wps:wsp/wps:spPr/a:xfrm", ns = xml_ns( doc ))
   expect_is(object = xfrm_node, class = "xml_node")
 
-  off_node <- xml_find_one(doc, ".//wps:wsp/wps:spPr/a:xfrm/a:off", ns = xml_ns( doc ))
+  off_node <- xml_find_first(doc, ".//wps:wsp/wps:spPr/a:xfrm/a:off", ns = xml_ns( doc ))
   offx <- xml_attr(off_node, "x")
   offy <- xml_attr(off_node, "y")
   expect_true( grepl("^[0-9]+$", offx ) )
   expect_true( grepl("^[0-9]+$", offy ) )
 
-  ext_node <- xml_find_one(doc, ".//wps:wsp/wps:spPr/a:xfrm/a:ext", ns = xml_ns( doc ))
+  ext_node <- xml_find_first(doc, ".//wps:wsp/wps:spPr/a:xfrm/a:ext", ns = xml_ns( doc ))
   cx <- xml_attr(ext_node, "cx")
   cy <- xml_attr(ext_node, "cy")
   expect_true( grepl("^[0-9]+$", cx ) )
@@ -70,16 +70,16 @@ test_that("polygon has dimensions", {
 
 
   doc <- read_xml(file)
-  xfrm_node <- xml_find_one(doc, ".//wps:wsp/wps:spPr/a:xfrm", ns = xml_ns( doc ))
+  xfrm_node <- xml_find_first(doc, ".//wps:wsp/wps:spPr/a:xfrm", ns = xml_ns( doc ))
   expect_is(object = xfrm_node, class = "xml_node")
 
-  off_node <- xml_find_one(doc, ".//wps:wsp/wps:spPr/a:xfrm/a:off", ns = xml_ns( doc ))
+  off_node <- xml_find_first(doc, ".//wps:wsp/wps:spPr/a:xfrm/a:off", ns = xml_ns( doc ))
   offx <- xml_attr(off_node, "x")
   offy <- xml_attr(off_node, "y")
   expect_true( grepl("^[0-9]+$", offx ) )
   expect_true( grepl("^[0-9]+$", offy ) )
 
-  ext_node <- xml_find_one(doc, ".//wps:wsp/wps:spPr/a:xfrm/a:ext", ns = xml_ns( doc ))
+  ext_node <- xml_find_first(doc, ".//wps:wsp/wps:spPr/a:xfrm/a:ext", ns = xml_ns( doc ))
   cx <- xml_attr(ext_node, "cx")
   cy <- xml_attr(ext_node, "cy")
   expect_true( grepl("^[0-9]+$", cx ) )
@@ -96,16 +96,16 @@ test_that("text has dimensions", {
   dev.off()
 
   doc <- read_xml(file)
-  xfrm_node <- xml_find_one(doc, ".//wps:wsp/wps:spPr/a:xfrm", ns = xml_ns( doc ))
+  xfrm_node <- xml_find_first(doc, ".//wps:wsp/wps:spPr/a:xfrm", ns = xml_ns( doc ))
   expect_is(object = xfrm_node, class = "xml_node")
 
-  off_node <- xml_find_one(doc, ".//wps:wsp/wps:spPr/a:xfrm/a:off", ns = xml_ns( doc ))
+  off_node <- xml_find_first(doc, ".//wps:wsp/wps:spPr/a:xfrm/a:off", ns = xml_ns( doc ))
   offx <- xml_attr(off_node, "x")
   offy <- xml_attr(off_node, "y")
   expect_true( grepl("^[0-9]+$", offx ) )
   expect_true( grepl("^[0-9]+$", offy ) )
 
-  ext_node <- xml_find_one(doc, ".//wps:wsp/wps:spPr/a:xfrm/a:ext", ns = xml_ns( doc ))
+  ext_node <- xml_find_first(doc, ".//wps:wsp/wps:spPr/a:xfrm/a:ext", ns = xml_ns( doc ))
   cx <- xml_attr(ext_node, "cx")
   cy <- xml_attr(ext_node, "cy")
   expect_true( grepl("^[0-9]+$", cx ) )

--- a/tests/testthat/test-pptx-lines.R
+++ b/tests/testthat/test-pptx-lines.R
@@ -10,7 +10,7 @@ test_that("segments don't have fill", {
   dev.off()
 
   doc <- read_xml(file)
-  fill_node <- try(xml_find_one(doc, ".//p:sp/p:spPr/a:solidFill", ns = xml_ns( doc ) ), silent = TRUE )
+  fill_node <- try(xml_find_first(doc, ".//p:sp/p:spPr/a:solidFill", ns = xml_ns( doc ) ), silent = TRUE )
   expect_true( inherits(fill_node, "try-error") )
 })
 
@@ -23,7 +23,7 @@ test_that("lines don't have fill", {
   dev.off()
 
   doc <- read_xml(file)
-  fill_node <- try(xml_find_one(doc, ".//p:sp/p:spPr/a:solidFill", ns = xml_ns( doc ) ), silent = TRUE )
+  fill_node <- try(xml_find_first(doc, ".//p:sp/p:spPr/a:solidFill", ns = xml_ns( doc ) ), silent = TRUE )
   expect_true( inherits(fill_node, "try-error") )
 })
 
@@ -35,7 +35,7 @@ test_that("polygons do have fill", {
   dev.off()
 
   doc <- read_xml(file)
-  fill_node <- try(xml_find_one(doc, ".//p:sp/p:spPr/a:solidFill", ns = xml_ns( doc ) ), silent = TRUE )
+  fill_node <- try(xml_find_first(doc, ".//p:sp/p:spPr/a:solidFill", ns = xml_ns( doc ) ), silent = TRUE )
   expect_false( inherits(fill_node, "try-error") )
 })
 
@@ -47,10 +47,10 @@ test_that("polygons without border", {
   dev.off()
 
   doc <- read_xml(file)
-  fill_color <- try(xml_find_one(doc, ".//p:sp/p:spPr/a:solidFill/a:srgbClr", ns = xml_ns( doc ) ), silent = TRUE )
+  fill_color <- try(xml_find_first(doc, ".//p:sp/p:spPr/a:solidFill/a:srgbClr", ns = xml_ns( doc ) ), silent = TRUE )
   expect_equal(xml_attr(fill_color, "val"), "FF0000")
 
-  line_color <- try( xml_find_one(doc, ".//p:sp/p:spPr/a:ln", ns = xml_ns( doc )), silent = TRUE )
+  line_color <- try( xml_find_first(doc, ".//p:sp/p:spPr/a:ln", ns = xml_ns( doc )), silent = TRUE )
   expect_true( inherits(line_color, "try-error") )
 
 })
@@ -62,7 +62,7 @@ dash_array <- function(...) {
   dev.off()
 
   doc <- read_xml(file)
-  dash <- try(xml_find_one(doc, ".//p:sp/p:spPr/a:ln/a:prstDash", ns = xml_ns( doc )), silent = TRUE )
+  dash <- try(xml_find_first(doc, ".//p:sp/p:spPr/a:ln/a:prstDash", ns = xml_ns( doc )), silent = TRUE )
   dash
 }
 custom_dash_array <- function(...) {
@@ -101,7 +101,7 @@ test_that("line join shapes", {
   dev.off()
 
   doc <- read_xml(file)
-  join_shape <- try(xml_find_one(doc, ".//p:sp/p:spPr/a:ln/a:round", ns = xml_ns( doc ) ), silent = TRUE )
+  join_shape <- try(xml_find_first(doc, ".//p:sp/p:spPr/a:ln/a:round", ns = xml_ns( doc ) ), silent = TRUE )
   expect_false( inherits(join_shape, "try-error") )
 
   file <- tempfile()
@@ -111,7 +111,7 @@ test_that("line join shapes", {
   dev.off()
 
   doc <- read_xml(file)
-  join_shape <- try(xml_find_one(doc, ".//p:sp/p:spPr/a:ln/a:miter", ns = xml_ns( doc ) ), silent = TRUE )
+  join_shape <- try(xml_find_first(doc, ".//p:sp/p:spPr/a:ln/a:miter", ns = xml_ns( doc ) ), silent = TRUE )
   expect_false( inherits(join_shape, "try-error") )
 
   file <- tempfile()
@@ -121,6 +121,6 @@ test_that("line join shapes", {
   dev.off()
 
   doc <- read_xml(file)
-  join_shape <- try(xml_find_one(doc, ".//p:sp/p:spPr/a:ln/a:bevel", ns = xml_ns( doc ) ), silent = TRUE )
+  join_shape <- try(xml_find_first(doc, ".//p:sp/p:spPr/a:ln/a:bevel", ns = xml_ns( doc ) ), silent = TRUE )
   expect_false( inherits(join_shape, "try-error") )
 })

--- a/tests/testthat/test-pptx-raster.R
+++ b/tests/testthat/test-pptx-raster.R
@@ -33,10 +33,10 @@ test_that("pic tag can be found", {
 
 
   doc <- read_xml(file)
-  pic_node <- try( xml_find_one(doc, ".//p:pic", ns = xml_ns( doc )), silent = TRUE )
+  pic_node <- try( xml_find_first(doc, ".//p:pic", ns = xml_ns( doc )), silent = TRUE )
   expect_false( inherits(pic_node, "try-error") )
 
-  blip_node <- try( xml_find_one(pic_node, ".//a:blip", ns = xml_ns( doc )), silent = TRUE )
+  blip_node <- try( xml_find_first(pic_node, ".//a:blip", ns = xml_ns( doc )), silent = TRUE )
   expect_false( inherits(blip_node, "try-error") )
 })
 

--- a/tests/testthat/test-pptx-text.R
+++ b/tests/testthat/test-pptx-text.R
@@ -9,7 +9,7 @@ test_that("text can be found", {
   dev.off()
 
   doc <- read_xml(file)
-  text_node <- xml_find_one(doc, ".//p:sp/p:txBody/a:p/a:r/a:t", ns = xml_ns( doc ))
+  text_node <- xml_find_first(doc, ".//p:sp/p:txBody/a:p/a:r/a:t", ns = xml_ns( doc ))
   expect_is(object = text_node, class = "xml_node")
   expect_equal(xml_text(text_node), "hello")
 })
@@ -34,7 +34,7 @@ test_that("special characters are escaped", {
 
   x <- read_xml(file)
   ns <-  xml_ns( x )
-  expect_equal(xml_text(xml_find_one(x, ".//p:sp/p:txBody/a:p/a:r/a:t", ns = ns )), "<&>")
+  expect_equal(xml_text(xml_find_first(x, ".//p:sp/p:txBody/a:p/a:r/a:t", ns = ns )), "<&>")
 })
 
 test_that("utf-8 characters are preserved", {
@@ -48,7 +48,7 @@ test_that("utf-8 characters are preserved", {
 
   x <- read_xml(file)
   ns <-  xml_ns( x )
-  expect_equal(xml_text(xml_find_one(x, ".//p:sp/p:txBody/a:p/a:r/a:t", ns = ns )), "\u00b5")
+  expect_equal(xml_text(xml_find_first(x, ".//p:sp/p:txBody/a:p/a:r/a:t", ns = ns )), "\u00b5")
 })
 
 test_that("text color is written in fill attr", {
@@ -60,7 +60,7 @@ test_that("text color is written in fill attr", {
 
   x <- read_xml(file)
   ns <-  xml_ns( x )
-  expect_equal( xml_attr( xml_find_one(x, ".//p:sp/p:txBody/a:p/a:r/a:rPr/a:solidFill/a:srgbClr", ns = ns ), "val" ), "113399" )
+  expect_equal( xml_attr( xml_find_first(x, ".//p:sp/p:txBody/a:p/a:r/a:rPr/a:solidFill/a:srgbClr", ns = ns ), "val" ), "113399" )
 })
 
 test_that("default point size is 12", {
@@ -72,7 +72,7 @@ test_that("default point size is 12", {
 
   x <- read_xml(file)
   ns <-  xml_ns( x )
-  rPr <- xml_find_one(x, ".//p:sp/p:txBody/a:p/a:r/a:rPr", ns = ns )
+  rPr <- xml_find_first(x, ".//p:sp/p:txBody/a:p/a:r/a:rPr", ns = ns )
   expect_equal(xml_attr(rPr, "sz"), "1200")
 })
 
@@ -85,7 +85,7 @@ test_that("cex does not generate fractional font sizes", {
 
   x <- read_xml(file)
   ns <-  xml_ns( x )
-  rPr <- xml_find_one(x, ".//p:sp/p:txBody/a:p/a:r/a:rPr", ns = ns )
+  rPr <- xml_find_first(x, ".//p:sp/p:txBody/a:p/a:r/a:rPr", ns = ns )
   expect_equal(xml_attr(rPr, "sz"), "120")
 })
 
@@ -145,8 +145,8 @@ test_that("symbol font family is 'Symbol'", {
 
   x <- read_xml(file)
   ns <-  xml_ns( x )
-  rPr_latin <- xml_find_one(x, ".//p:sp/p:txBody/a:p/a:r/a:rPr/a:latin", ns = ns )
-  rPr_cs <- xml_find_one(x, ".//p:sp/p:txBody/a:p/a:r/a:rPr/a:cs", ns = ns )
+  rPr_latin <- xml_find_first(x, ".//p:sp/p:txBody/a:p/a:r/a:rPr/a:latin", ns = ns )
+  rPr_cs <- xml_find_first(x, ".//p:sp/p:txBody/a:p/a:r/a:rPr/a:cs", ns = ns )
   expect_equal(xml_attr(rPr_latin, "typeface"), c("Symbol"))
   expect_equal(xml_attr(rPr_cs, "typeface"), c("Symbol"))
 })

--- a/tests/testthat/test-pptx-xfrm.R
+++ b/tests/testthat/test-pptx-xfrm.R
@@ -12,16 +12,16 @@ test_that("rect has dimensions", {
 
 
   doc <- read_xml(file)
-  xfrm_node <- xml_find_one(doc, ".//p:sp/p:spPr/a:xfrm", ns = xml_ns( doc ))
+  xfrm_node <- xml_find_first(doc, ".//p:sp/p:spPr/a:xfrm", ns = xml_ns( doc ))
   expect_is(object = xfrm_node, class = "xml_node")
 
-  off_node <- xml_find_one(doc, ".//p:sp/p:spPr/a:xfrm/a:off", ns = xml_ns( doc ))
+  off_node <- xml_find_first(doc, ".//p:sp/p:spPr/a:xfrm/a:off", ns = xml_ns( doc ))
   offx <- xml_attr(off_node, "x")
   offy <- xml_attr(off_node, "y")
   expect_true( grepl("^[0-9]+$", offx ) )
   expect_true( grepl("^[0-9]+$", offy ) )
 
-  ext_node <- xml_find_one(doc, ".//p:sp/p:spPr/a:xfrm/a:ext", ns = xml_ns( doc ))
+  ext_node <- xml_find_first(doc, ".//p:sp/p:spPr/a:xfrm/a:ext", ns = xml_ns( doc ))
   cx <- xml_attr(ext_node, "cx")
   cy <- xml_attr(ext_node, "cy")
   expect_true( grepl("^[0-9]+$", cx ) )
@@ -39,16 +39,16 @@ test_that("lines has dimensions", {
 
 
   doc <- read_xml(file)
-  xfrm_node <- xml_find_one(doc, ".//p:sp/p:spPr/a:xfrm", ns = xml_ns( doc ))
+  xfrm_node <- xml_find_first(doc, ".//p:sp/p:spPr/a:xfrm", ns = xml_ns( doc ))
   expect_is(object = xfrm_node, class = "xml_node")
 
-  off_node <- xml_find_one(doc, ".//p:sp/p:spPr/a:xfrm/a:off", ns = xml_ns( doc ))
+  off_node <- xml_find_first(doc, ".//p:sp/p:spPr/a:xfrm/a:off", ns = xml_ns( doc ))
   offx <- xml_attr(off_node, "x")
   offy <- xml_attr(off_node, "y")
   expect_true( grepl("^[0-9]+$", offx ) )
   expect_true( grepl("^[0-9]+$", offy ) )
 
-  ext_node <- xml_find_one(doc, ".//p:sp/p:spPr/a:xfrm/a:ext", ns = xml_ns( doc ))
+  ext_node <- xml_find_first(doc, ".//p:sp/p:spPr/a:xfrm/a:ext", ns = xml_ns( doc ))
   cx <- xml_attr(ext_node, "cx")
   cy <- xml_attr(ext_node, "cy")
   expect_true( grepl("^[0-9]+$", cx ) )
@@ -70,16 +70,16 @@ test_that("polygon has dimensions", {
 
 
   doc <- read_xml(file)
-  xfrm_node <- xml_find_one(doc, ".//p:sp/p:spPr/a:xfrm", ns = xml_ns( doc ))
+  xfrm_node <- xml_find_first(doc, ".//p:sp/p:spPr/a:xfrm", ns = xml_ns( doc ))
   expect_is(object = xfrm_node, class = "xml_node")
 
-  off_node <- xml_find_one(doc, ".//p:sp/p:spPr/a:xfrm/a:off", ns = xml_ns( doc ))
+  off_node <- xml_find_first(doc, ".//p:sp/p:spPr/a:xfrm/a:off", ns = xml_ns( doc ))
   offx <- xml_attr(off_node, "x")
   offy <- xml_attr(off_node, "y")
   expect_true( grepl("^[0-9]+$", offx ) )
   expect_true( grepl("^[0-9]+$", offy ) )
 
-  ext_node <- xml_find_one(doc, ".//p:sp/p:spPr/a:xfrm/a:ext", ns = xml_ns( doc ))
+  ext_node <- xml_find_first(doc, ".//p:sp/p:spPr/a:xfrm/a:ext", ns = xml_ns( doc ))
   cx <- xml_attr(ext_node, "cx")
   cy <- xml_attr(ext_node, "cy")
   expect_true( grepl("^[0-9]+$", cx ) )
@@ -98,16 +98,16 @@ test_that("text has dimensions", {
 
 
   doc <- read_xml(file)
-  xfrm_node <- xml_find_one(doc, ".//p:sp/p:spPr/a:xfrm", ns = xml_ns( doc ))
+  xfrm_node <- xml_find_first(doc, ".//p:sp/p:spPr/a:xfrm", ns = xml_ns( doc ))
   expect_is(object = xfrm_node, class = "xml_node")
 
-  off_node <- xml_find_one(doc, ".//p:sp/p:spPr/a:xfrm/a:off", ns = xml_ns( doc ))
+  off_node <- xml_find_first(doc, ".//p:sp/p:spPr/a:xfrm/a:off", ns = xml_ns( doc ))
   offx <- xml_attr(off_node, "x")
   offy <- xml_attr(off_node, "y")
   expect_true( grepl("^[0-9]+$", offx ) )
   expect_true( grepl("^[0-9]+$", offy ) )
 
-  ext_node <- xml_find_one(doc, ".//p:sp/p:spPr/a:xfrm/a:ext", ns = xml_ns( doc ))
+  ext_node <- xml_find_first(doc, ".//p:sp/p:spPr/a:xfrm/a:ext", ns = xml_ns( doc ))
   cx <- xml_attr(ext_node, "cx")
   cy <- xml_attr(ext_node, "cy")
   expect_true( grepl("^[0-9]+$", cx ) )

--- a/tests/testthat/test-svg-interactive.R
+++ b/tests/testthat/test-svg-interactive.R
@@ -31,7 +31,7 @@ test_that("attributes are written", {
   dev.off()
 
   doc <- read_xml(file)
-  script_node <- xml_find_one(doc, ".//script")
+  script_node <- xml_find_first(doc, ".//script")
   script_txt <-  xml_text(script_node)
   tip1 = "document\\.querySelectorAll\\('#svg_[0-9]+'\\)\\[0\\]\\.getElementById\\('[0-9]+'\\)\\.setAttribute\\('onclick','alert\\(1\\)'\\)"
   tip2 = "document\\.querySelectorAll\\('#svg_[0-9]+'\\)\\[0\\]\\.getElementById\\('[0-9]+'\\)\\.setAttribute\\('onclick','alert\\(2\\)'\\)"

--- a/tests/testthat/test-svg-lines.R
+++ b/tests/testthat/test-svg-lines.R
@@ -11,7 +11,7 @@ test_that("segments have stroke and no fill", {
   dev.off()
 
   x <- read_xml(file)
-  seg_node <- xml_find_one(x, "//line")
+  seg_node <- xml_find_first(x, "//line")
   expect_match(xml_attr(seg_node, "fill"), "none")
   expect_match(xml_attr(seg_node, "stroke"), "#000000")
 })
@@ -24,7 +24,7 @@ test_that("lines have stroke and no fill", {
   dev.off()
 
   x <- read_xml(file)
-  seg_node <- xml_find_one(x, "//polyline")
+  seg_node <- xml_find_first(x, "//polyline")
   expect_match(xml_attr(seg_node, "fill"), "none")
   expect_match(xml_attr(seg_node, "stroke"), "#000000")
 })
@@ -37,7 +37,7 @@ test_that("polygons do have fill and stroke", {
   dev.off()
 
   x <- read_xml(file)
-  svg_node <- xml_find_one(x, "//polygon")
+  svg_node <- xml_find_first(x, "//polygon")
   expect_match(xml_attr(svg_node, "fill"), "#FF0000")
   expect_match(xml_attr(svg_node, "stroke"), "#0000FF")
 })
@@ -50,7 +50,7 @@ test_that("polygons without border have fill and no stroke", {
   dev.off()
 
   x <- read_xml(file)
-  svg_node <- xml_find_one(x, "//polygon")
+  svg_node <- xml_find_first(x, "//polygon")
   expect_equal(xml_attr(svg_node, "fill"), "#FF0000")
   expect_equal(xml_attr(svg_node, "stroke"), "none")
 })
@@ -73,7 +73,7 @@ dash_array <- function(...) {
   lines(c(0,1), c(0.5,.7), ...)
   dev.off()
   doc <- read_xml(file)
-  dash <- xml_attr(xml_find_one(doc, "//polyline"), "stroke-dasharray")
+  dash <- xml_attr(xml_find_first(doc, "//polyline"), "stroke-dasharray")
   as.integer(strsplit(dash, ",")[[1]])
 }
 
@@ -115,13 +115,13 @@ test_that("line end shapes", {
   dev.off()
   x3 <- read_xml(file)
 
-  linecap <- xml_attr(xml_find_one(x1, "//polyline"), "stroke-linecap")
+  linecap <- xml_attr(xml_find_first(x1, "//polyline"), "stroke-linecap")
   expect_match(linecap, "round")
 
-  linecap <- xml_attr(xml_find_one(x2, "//polyline"), "stroke-linecap")
+  linecap <- xml_attr(xml_find_first(x2, "//polyline"), "stroke-linecap")
   expect_match(linecap, "butt")
 
-  linecap <- xml_attr(xml_find_one(x3, "//polyline"), "stroke-linecap")
+  linecap <- xml_attr(xml_find_first(x3, "//polyline"), "stroke-linecap")
   expect_match(linecap, "square")
 })
 
@@ -133,7 +133,7 @@ test_that("line join shapes", {
   lines(c(0.3, 0.5, 0.7), c(0.1, 0.9, 0.1), lwd = 15, ljoin = "round")
   dev.off()
   x1 <- read_xml(file)
-  linejoin <- xml_attr(xml_find_one(x1, "//polyline"), "stroke-linejoin")
+  linejoin <- xml_attr(xml_find_first(x1, "//polyline"), "stroke-linejoin")
   expect_match(linejoin, "round")
 
   file <- tempfile(fileext = ".svg")
@@ -142,7 +142,7 @@ test_that("line join shapes", {
   lines(c(0.3, 0.5, 0.7), c(0.1, 0.9, 0.1), lwd = 15, ljoin = "mitre")
   dev.off()
   x2 <- read_xml(file)
-  linejoin <- xml_attr(xml_find_one(x2, "//polyline"), "stroke-linejoin")
+  linejoin <- xml_attr(xml_find_first(x2, "//polyline"), "stroke-linejoin")
   expect_match(linejoin, "miter")
 
   file <- tempfile(fileext = ".svg")
@@ -151,6 +151,6 @@ test_that("line join shapes", {
   lines(c(0.3, 0.5, 0.7), c(0.1, 0.9, 0.1), lwd = 15, ljoin = "bevel")
   dev.off()
   x3 <- read_xml(file)
-  linejoin <- xml_attr(xml_find_one(x3, "//polyline"), "stroke-linejoin")
+  linejoin <- xml_attr(xml_find_first(x3, "//polyline"), "stroke-linejoin")
   expect_match(linejoin, "bevel")
 })

--- a/tests/testthat/test-svg-points.R
+++ b/tests/testthat/test-svg-points.R
@@ -10,7 +10,7 @@ test_that("radius is given in points", {
   dev.off()
 
   x <- read_xml(file)
-  node <- xml_find_one(x, ".//circle")
+  node <- xml_find_first(x, ".//circle")
 
   expect_equal(xml_attr(node, "r"), "33.75pt")
 })
@@ -23,7 +23,7 @@ test_that("check stroke and fill exist", {
   dev.off()
 
   x <- read_xml(file)
-  node <- xml_find_one(x, ".//circle")
+  node <- xml_find_first(x, ".//circle")
   expect_equal(xml_attr(node, "stroke"), "#FF0000")
   expect_equal(xml_attr(node, "fill"), "#0000FF")
 })
@@ -37,7 +37,7 @@ test_that("check alpha values", {
   dev.off()
 
   x <- read_xml(file)
-  node <- xml_find_one(x, ".//circle")
+  node <- xml_find_first(x, ".//circle")
   expect_equal(xml_attr(node, "stroke"), "#FF0000" )
   expect_equal(xml_attr(node, "stroke-opacity"), "0.5")
   expect_equal(xml_attr(node, "fill"), "#00FFFF")
@@ -52,7 +52,7 @@ test_that("check fill is set to none when necessary", {
   dev.off()
 
   x <- read_xml(file)
-  node <- xml_find_one(x, ".//circle")
+  node <- xml_find_first(x, ".//circle")
   expect_match(xml_attr(node, "fill"), "none")
 })
 

--- a/tests/testthat/test-svg-text.R
+++ b/tests/testthat/test-svg-text.R
@@ -22,7 +22,7 @@ test_that("special characters are escaped", {
   dev.off()
 
   x <- read_xml(file)
-  expect_equal(xml_text(xml_find_one(x, ".//text")), "<&>")
+  expect_equal(xml_text(xml_find_first(x, ".//text")), "<&>")
 })
 
 test_that("utf-8 characters are preserved", {
@@ -35,7 +35,7 @@ test_that("utf-8 characters are preserved", {
   dev.off()
 
   x <- read_xml(file)
-  expect_equal(xml_text(xml_find_one(x, ".//text")), "\u00b5")
+  expect_equal(xml_text(xml_find_first(x, ".//text")), "\u00b5")
 })
 
 test_that("text color is written in fill attr", {
@@ -47,7 +47,7 @@ test_that("text color is written in fill attr", {
   dev.off()
 
   x <- read_xml(file)
-  expect_equal(xml_attr(xml_find_one(x, ".//text"), "fill"), "#113399")
+  expect_equal(xml_attr(xml_find_first(x, ".//text"), "fill"), "#113399")
 })
 
 test_that("default point size is 12", {
@@ -58,7 +58,7 @@ test_that("default point size is 12", {
   dev.off()
 
   x <- read_xml(file)
-  expect_equal(xml_attr(xml_find_one(x, ".//text"), "font-size"), "9.00pt")
+  expect_equal(xml_attr(xml_find_first(x, ".//text"), "font-size"), "9.00pt")
 })
 
 test_that("cex generates fractional font sizes", {
@@ -69,7 +69,7 @@ test_that("cex generates fractional font sizes", {
   dev.off()
 
   x <- read_xml(file)
-  expect_equal(xml_attr(xml_find_one(x, ".//text"), "font-size"), "0.90pt")
+  expect_equal(xml_attr(xml_find_first(x, ".//text"), "font-size"), "0.90pt")
 })
 
 test_that("font sets weight/style", {

--- a/tests/testthat/test-xlsx-lines.R
+++ b/tests/testthat/test-xlsx-lines.R
@@ -10,7 +10,7 @@ test_that("segments don't have fill", {
   dev.off()
 
   doc <- read_xml(file)
-  fill_node <- try(xml_find_one(doc, ".//xdr:sp/xdr:spPr/a:solidFill", ns = xml_ns( doc ) ), silent = TRUE )
+  fill_node <- try(xml_find_first(doc, ".//xdr:sp/xdr:spPr/a:solidFill", ns = xml_ns( doc ) ), silent = TRUE )
   expect_true( inherits(fill_node, "try-error") )
 })
 
@@ -23,7 +23,7 @@ test_that("lines don't have fill", {
   dev.off()
 
   doc <- read_xml(file)
-  fill_node <- try(xml_find_one(doc, ".//xdr:sp/xdr:spPr/a:solidFill", ns = xml_ns( doc ) ), silent = TRUE )
+  fill_node <- try(xml_find_first(doc, ".//xdr:sp/xdr:spPr/a:solidFill", ns = xml_ns( doc ) ), silent = TRUE )
   expect_true( inherits(fill_node, "try-error") )
 })
 
@@ -35,7 +35,7 @@ test_that("polygons do have fill", {
   dev.off()
 
   doc <- read_xml(file)
-  fill_node <- try(xml_find_one(doc, ".//xdr:sp/xdr:spPr/a:solidFill", ns = xml_ns( doc ) ), silent = TRUE )
+  fill_node <- try(xml_find_first(doc, ".//xdr:sp/xdr:spPr/a:solidFill", ns = xml_ns( doc ) ), silent = TRUE )
   expect_false( inherits(fill_node, "try-error") )
 })
 
@@ -47,10 +47,10 @@ test_that("polygons without border", {
   dev.off()
 
   doc <- read_xml(file)
-  fill_color <- try(xml_find_one(doc, ".//xdr:sp/xdr:spPr/a:solidFill/a:srgbClr", ns = xml_ns( doc ) ), silent = TRUE )
+  fill_color <- try(xml_find_first(doc, ".//xdr:sp/xdr:spPr/a:solidFill/a:srgbClr", ns = xml_ns( doc ) ), silent = TRUE )
   expect_equal(xml_attr(fill_color, "val"), "FF0000")
 
-  line_color <- try( xml_find_one(doc, ".//xdr:sp/xdr:spPr/a:ln", ns = xml_ns( doc )), silent = TRUE )
+  line_color <- try( xml_find_first(doc, ".//xdr:sp/xdr:spPr/a:ln", ns = xml_ns( doc )), silent = TRUE )
   expect_true( inherits(line_color, "try-error") )
 
 })
@@ -62,7 +62,7 @@ dash_array <- function(...) {
   dev.off()
 
   doc <- read_xml(file)
-  dash <- try(xml_find_one(doc, ".//xdr:sp/xdr:spPr/a:ln/a:prstDash", ns = xml_ns( doc )), silent = TRUE )
+  dash <- try(xml_find_first(doc, ".//xdr:sp/xdr:spPr/a:ln/a:prstDash", ns = xml_ns( doc )), silent = TRUE )
   dash
 }
 custom_dash_array <- function(...) {
@@ -101,7 +101,7 @@ test_that("line join shapes", {
   dev.off()
 
   doc <- read_xml(file)
-  join_shape <- try(xml_find_one(doc, ".//xdr:sp/xdr:spPr/a:ln/a:round", ns = xml_ns( doc ) ), silent = TRUE )
+  join_shape <- try(xml_find_first(doc, ".//xdr:sp/xdr:spPr/a:ln/a:round", ns = xml_ns( doc ) ), silent = TRUE )
   expect_false( inherits(join_shape, "try-error") )
 
   file <- tempfile()
@@ -111,7 +111,7 @@ test_that("line join shapes", {
   dev.off()
 
   doc <- read_xml(file)
-  join_shape <- try(xml_find_one(doc, ".//xdr:sp/xdr:spPr/a:ln/a:miter", ns = xml_ns( doc ) ), silent = TRUE )
+  join_shape <- try(xml_find_first(doc, ".//xdr:sp/xdr:spPr/a:ln/a:miter", ns = xml_ns( doc ) ), silent = TRUE )
   expect_false( inherits(join_shape, "try-error") )
 
   file <- tempfile()
@@ -121,6 +121,6 @@ test_that("line join shapes", {
   dev.off()
 
   doc <- read_xml(file)
-  join_shape <- try(xml_find_one(doc, ".//xdr:sp/xdr:spPr/a:ln/a:bevel", ns = xml_ns( doc ) ), silent = TRUE )
+  join_shape <- try(xml_find_first(doc, ".//xdr:sp/xdr:spPr/a:ln/a:bevel", ns = xml_ns( doc ) ), silent = TRUE )
   expect_false( inherits(join_shape, "try-error") )
 })

--- a/tests/testthat/test-xlsx-raster.R
+++ b/tests/testthat/test-xlsx-raster.R
@@ -33,10 +33,10 @@ test_that("pic tag can be found", {
 
 
   doc <- read_xml(file)
-  pic_node <- try( xml_find_one(doc, ".//xdr:pic", ns = xml_ns( doc )), silent = TRUE )
+  pic_node <- try( xml_find_first(doc, ".//xdr:pic", ns = xml_ns( doc )), silent = TRUE )
   expect_false( inherits(pic_node, "try-error") )
 
-  blip_node <- try( xml_find_one(pic_node, ".//a:blip", ns = xml_ns( doc )), silent = TRUE )
+  blip_node <- try( xml_find_first(pic_node, ".//a:blip", ns = xml_ns( doc )), silent = TRUE )
   expect_false( inherits(blip_node, "try-error") )
 })
 

--- a/tests/testthat/test-xlsx-text.R
+++ b/tests/testthat/test-xlsx-text.R
@@ -9,7 +9,7 @@ test_that("text can be found", {
   dev.off()
 
   doc <- read_xml(file)
-  text_node <- xml_find_one(doc, ".//xdr:sp/xdr:txBody/a:p/a:r/a:t", ns = xml_ns( doc ))
+  text_node <- xml_find_first(doc, ".//xdr:sp/xdr:txBody/a:p/a:r/a:t", ns = xml_ns( doc ))
   expect_is(object = text_node, class = "xml_node")
   expect_equal(xml_text(text_node), "hello")
 })
@@ -34,7 +34,7 @@ test_that("special characters are escaped", {
 
   x <- read_xml(file)
   ns <-  xml_ns( x )
-  expect_equal(xml_text(xml_find_one(x, ".//xdr:sp/xdr:txBody/a:p/a:r/a:t", ns = ns )), "<&>")
+  expect_equal(xml_text(xml_find_first(x, ".//xdr:sp/xdr:txBody/a:p/a:r/a:t", ns = ns )), "<&>")
 })
 
 test_that("utf-8 characters are preserved", {
@@ -48,7 +48,7 @@ test_that("utf-8 characters are preserved", {
 
   x <- read_xml(file)
   ns <-  xml_ns( x )
-  expect_equal(xml_text(xml_find_one(x, ".//xdr:sp/xdr:txBody/a:p/a:r/a:t", ns = ns )), "\u00b5")
+  expect_equal(xml_text(xml_find_first(x, ".//xdr:sp/xdr:txBody/a:p/a:r/a:t", ns = ns )), "\u00b5")
 })
 
 test_that("text color is written in fill attr", {
@@ -60,7 +60,7 @@ test_that("text color is written in fill attr", {
 
   x <- read_xml(file)
   ns <-  xml_ns( x )
-  expect_equal( xml_attr( xml_find_one(x, ".//xdr:sp/xdr:txBody/a:p/a:r/a:rPr/a:solidFill/a:srgbClr", ns = ns ), "val" ), "113399" )
+  expect_equal( xml_attr( xml_find_first(x, ".//xdr:sp/xdr:txBody/a:p/a:r/a:rPr/a:solidFill/a:srgbClr", ns = ns ), "val" ), "113399" )
 })
 
 test_that("default point size is 12", {
@@ -72,7 +72,7 @@ test_that("default point size is 12", {
 
   x <- read_xml(file)
   ns <-  xml_ns( x )
-  rPr <- xml_find_one(x, ".//xdr:sp/xdr:txBody/a:p/a:r/a:rPr", ns = ns )
+  rPr <- xml_find_first(x, ".//xdr:sp/xdr:txBody/a:p/a:r/a:rPr", ns = ns )
   expect_equal(xml_attr(rPr, "sz"), "1200")
 })
 
@@ -85,7 +85,7 @@ test_that("cex does not generate fractional font sizes", {
 
   x <- read_xml(file)
   ns <-  xml_ns( x )
-  rPr <- xml_find_one(x, ".//xdr:sp/xdr:txBody/a:p/a:r/a:rPr", ns = ns )
+  rPr <- xml_find_first(x, ".//xdr:sp/xdr:txBody/a:p/a:r/a:rPr", ns = ns )
   expect_equal(xml_attr(rPr, "sz"), "120")
 })
 
@@ -145,8 +145,8 @@ test_that("symbol font family is 'Symbol'", {
 
   x <- read_xml(file)
   ns <-  xml_ns( x )
-  rPr_latin <- xml_find_one(x, ".//xdr:sp/xdr:txBody/a:p/a:r/a:rPr/a:latin", ns = ns )
-  rPr_cs <- xml_find_one(x, ".//xdr:sp/xdr:txBody/a:p/a:r/a:rPr/a:cs", ns = ns )
+  rPr_latin <- xml_find_first(x, ".//xdr:sp/xdr:txBody/a:p/a:r/a:rPr/a:latin", ns = ns )
+  rPr_cs <- xml_find_first(x, ".//xdr:sp/xdr:txBody/a:p/a:r/a:rPr/a:cs", ns = ns )
   expect_equal(xml_attr(rPr_latin, "typeface"), c("Symbol"))
   expect_equal(xml_attr(rPr_cs, "typeface"), c("Symbol"))
 })

--- a/tests/testthat/test-xlsx-xfrm.R
+++ b/tests/testthat/test-xlsx-xfrm.R
@@ -12,16 +12,16 @@ test_that("rect has dimensions", {
 
 
   doc <- read_xml(file)
-  xfrm_node <- xml_find_one(doc, ".//xdr:sp/xdr:spPr/a:xfrm", ns = xml_ns( doc ))
+  xfrm_node <- xml_find_first(doc, ".//xdr:sp/xdr:spPr/a:xfrm", ns = xml_ns( doc ))
   expect_is(object = xfrm_node, class = "xml_node")
 
-  off_node <- xml_find_one(doc, ".//xdr:sp/xdr:spPr/a:xfrm/a:off", ns = xml_ns( doc ))
+  off_node <- xml_find_first(doc, ".//xdr:sp/xdr:spPr/a:xfrm/a:off", ns = xml_ns( doc ))
   offx <- xml_attr(off_node, "x")
   offy <- xml_attr(off_node, "y")
   expect_true( grepl("^[0-9]+$", offx ) )
   expect_true( grepl("^[0-9]+$", offy ) )
 
-  ext_node <- xml_find_one(doc, ".//xdr:sp/xdr:spPr/a:xfrm/a:ext", ns = xml_ns( doc ))
+  ext_node <- xml_find_first(doc, ".//xdr:sp/xdr:spPr/a:xfrm/a:ext", ns = xml_ns( doc ))
   cx <- xml_attr(ext_node, "cx")
   cy <- xml_attr(ext_node, "cy")
   expect_true( grepl("^[0-9]+$", cx ) )
@@ -39,16 +39,16 @@ test_that("lines has dimensions", {
 
 
   doc <- read_xml(file)
-  xfrm_node <- xml_find_one(doc, ".//xdr:sp/xdr:spPr/a:xfrm", ns = xml_ns( doc ))
+  xfrm_node <- xml_find_first(doc, ".//xdr:sp/xdr:spPr/a:xfrm", ns = xml_ns( doc ))
   expect_is(object = xfrm_node, class = "xml_node")
 
-  off_node <- xml_find_one(doc, ".//xdr:sp/xdr:spPr/a:xfrm/a:off", ns = xml_ns( doc ))
+  off_node <- xml_find_first(doc, ".//xdr:sp/xdr:spPr/a:xfrm/a:off", ns = xml_ns( doc ))
   offx <- xml_attr(off_node, "x")
   offy <- xml_attr(off_node, "y")
   expect_true( grepl("^[0-9]+$", offx ) )
   expect_true( grepl("^[0-9]+$", offy ) )
 
-  ext_node <- xml_find_one(doc, ".//xdr:sp/xdr:spPr/a:xfrm/a:ext", ns = xml_ns( doc ))
+  ext_node <- xml_find_first(doc, ".//xdr:sp/xdr:spPr/a:xfrm/a:ext", ns = xml_ns( doc ))
   cx <- xml_attr(ext_node, "cx")
   cy <- xml_attr(ext_node, "cy")
   expect_true( grepl("^[0-9]+$", cx ) )
@@ -70,16 +70,16 @@ test_that("polygon has dimensions", {
 
 
   doc <- read_xml(file)
-  xfrm_node <- xml_find_one(doc, ".//xdr:sp/xdr:spPr/a:xfrm", ns = xml_ns( doc ))
+  xfrm_node <- xml_find_first(doc, ".//xdr:sp/xdr:spPr/a:xfrm", ns = xml_ns( doc ))
   expect_is(object = xfrm_node, class = "xml_node")
 
-  off_node <- xml_find_one(doc, ".//xdr:sp/xdr:spPr/a:xfrm/a:off", ns = xml_ns( doc ))
+  off_node <- xml_find_first(doc, ".//xdr:sp/xdr:spPr/a:xfrm/a:off", ns = xml_ns( doc ))
   offx <- xml_attr(off_node, "x")
   offy <- xml_attr(off_node, "y")
   expect_true( grepl("^[0-9]+$", offx ) )
   expect_true( grepl("^[0-9]+$", offy ) )
 
-  ext_node <- xml_find_one(doc, ".//xdr:sp/xdr:spPr/a:xfrm/a:ext", ns = xml_ns( doc ))
+  ext_node <- xml_find_first(doc, ".//xdr:sp/xdr:spPr/a:xfrm/a:ext", ns = xml_ns( doc ))
   cx <- xml_attr(ext_node, "cx")
   cy <- xml_attr(ext_node, "cy")
   expect_true( grepl("^[0-9]+$", cx ) )
@@ -98,16 +98,16 @@ test_that("text has dimensions", {
 
 
   doc <- read_xml(file)
-  xfrm_node <- xml_find_one(doc, ".//xdr:sp/xdr:spPr/a:xfrm", ns = xml_ns( doc ))
+  xfrm_node <- xml_find_first(doc, ".//xdr:sp/xdr:spPr/a:xfrm", ns = xml_ns( doc ))
   expect_is(object = xfrm_node, class = "xml_node")
 
-  off_node <- xml_find_one(doc, ".//xdr:sp/xdr:spPr/a:xfrm/a:off", ns = xml_ns( doc ))
+  off_node <- xml_find_first(doc, ".//xdr:sp/xdr:spPr/a:xfrm/a:off", ns = xml_ns( doc ))
   offx <- xml_attr(off_node, "x")
   offy <- xml_attr(off_node, "y")
   expect_true( grepl("^[0-9]+$", offx ) )
   expect_true( grepl("^[0-9]+$", offy ) )
 
-  ext_node <- xml_find_one(doc, ".//xdr:sp/xdr:spPr/a:xfrm/a:ext", ns = xml_ns( doc ))
+  ext_node <- xml_find_first(doc, ".//xdr:sp/xdr:spPr/a:xfrm/a:ext", ns = xml_ns( doc ))
   cx <- xml_attr(ext_node, "cx")
   cy <- xml_attr(ext_node, "cy")
   expect_true( grepl("^[0-9]+$", cx ) )


### PR DESCRIPTION
The next version of xml2 will be deprecating xml_find_one() in favor of
xml_find_first(). The new function is a drop in replacement for the old, and no
longer issues a warning when more than one result would be returned.

This pull request also adds a `Remotes: hadley/xml2` entry to install the
development version of xml2. Once the new version of xml2 is released (2-4
weeks) this should be removed.
