### PR TITLE
Fix snprintf warnings

### DIFF
--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -5,6 +5,11 @@
 
 using namespace Rcpp;
 
+#ifdef RCPP_USE_GLOBAL_ROSTREAM
+Rcpp::Rostream<true>&  Rcpp::Rcout = Rcpp::Rcpp_cout_get();
+Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
+#endif
+
 // PPTX_
 bool PPTX_(std::string file, std::string bg_, double width, double height, double offx, double offy, int pointsize, Rcpp::List aliases, bool editable, int id, std::string raster_prefix, int last_rel_id, int standalone);
 RcppExport SEXP _rvg_PPTX_(SEXP fileSEXP, SEXP bg_SEXP, SEXP widthSEXP, SEXP heightSEXP, SEXP offxSEXP, SEXP offySEXP, SEXP pointsizeSEXP, SEXP aliasesSEXP, SEXP editableSEXP, SEXP idSEXP, SEXP raster_prefixSEXP, SEXP last_rel_idSEXP, SEXP standaloneSEXP) {

--- a/src/a_color.cpp
+++ b/src/a_color.cpp
@@ -8,7 +8,7 @@ std::string a_color::solid_fill()
 {
 
   char col_buf[ 100 ];
-  sprintf( col_buf, "%02X%02X%02X", R_RED(this->col), R_GREEN(this->col), R_BLUE(this->col));
+  snprintf(col_buf, sizeof(col_buf), "%02X%02X%02X", R_RED(this->col), R_GREEN(this->col), R_BLUE(this->col));
   std::string col_str = col_buf;
 
   std::stringstream os;


### PR DESCRIPTION
They can be seen [here](https://cran.r-project.org/web/checks/check_results_rvg.html). Might be triggered by `openxlsx2` suggesting `rvg`. The RcppExports is from some Rcpp update (don't remember from the top of my head what caused this).