### PR TITLE
Fix text not being vertically centered (Issue #31)

### DIFF
--- a/src/ppr.cpp
+++ b/src/ppr.cpp
@@ -16,7 +16,7 @@ std::string ppr::a_tag()
   else
     os << " algn=\"r\"";
   os << " marL=\"0\" marR=\"0\" indent=\"0\">";
-  os << "<a:lnSpc><a:spcPts val=\"" << (int)(this->lineheight*100) << "\"/></a:lnSpc>";
+  os << "<a:lnSpc><a:spcPct val=\"100%\"/></a:lnSpc>";
   os << "<a:spcBef><a:spcPts val=\"0\"/></a:spcBef>";
   os << "<a:spcAft><a:spcPts val=\"0\"/></a:spcAft>";
   os << "</a:pPr>";

--- a/src/text.cpp
+++ b/src/text.cpp
@@ -195,7 +195,10 @@ double pptx_strheight_utf8(const char *str, const pGEcontext gc, pDevDesc dd) {
   std::string file = fontfile(gc->fontfamily, gc->fontface, pptx_obj->system_aliases);
   std::string name = fontname(gc->fontfamily, gc->fontface, pptx_obj->system_aliases);
   gdtools::context_set_font(pptx_obj->cc, name, gc->cex * gc->ps, is_bold(gc->fontface), is_italic(gc->fontface), file);
-  FontMetric fm = gdtools::context_extents(pptx_obj->cc, std::string(str));
+  FontMetric fm = gdtools::context_extents(pptx_obj->cc, std::string("HI")); 
+  // Forces the height of pptx textbox to be cap-height which ensures correct vertical placement 
+  // when the vertical alignment of pptx textbox is centered/middle
+  // At least it works with Arial
   return fm.height;
 }
 double xlsx_strheight_utf8(const char *str, const pGEcontext gc, pDevDesc dd) {


### PR DESCRIPTION
I think this fixed the issue mentioned by @tomwenseleers in #31 and #30 

The lineheight is not nesscary to put into the DML because each line is created as a separate text element.  I have tested and seems to work with the following plot.

```
ggplot2::ggplot(data = ggplot2::txhousing |> dplyr::slice_sample(n=100)) + 
  aes(x=volume, y=sales) + 
  geom_point() + 
  annotate("text", x= 0.5*10^9, y = 7500, label="JAJA\nNY LINJE", lineheight=2) +
  annotate("text", x= 2*10^9, y = 5000, label="JAJA\nNY LINJE", lineheight=1) 
```

I hope you can use it. I have never created a real pull request before or have any prior experince with R-package development or C++.

Best regards,
Henrik
